### PR TITLE
Add HubSpot list membership, creation and deletion requests

### DIFF
--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -938,6 +938,13 @@ class Api extends OAuth2Requester {
         return this._post(options);
     }
 
+    async getList(listId) {
+        const options = {
+            url: this.baseUrl + this.URLs.listById(listId),
+        };
+        return this._get(options);
+    }
+
     async createList(name, objectTypeId, processingType = 'MANUAL', listFolderId = null) {
         const options = {
             url: this.baseUrl + this.URLs.lists,

--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -938,7 +938,7 @@ class Api extends OAuth2Requester {
         return this._post(options);
     }
 
-    async getList(listId) {
+    async getListById(listId) {
         const options = {
             url: this.baseUrl + this.URLs.listById(listId),
         };

--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -57,7 +57,9 @@ class Api extends OAuth2Requester {
             emailTemplates: '/content/api/v2/templates',
             emailTemplateById: (templateId) => `/content/api/v2/templates/${templateId}`,
             lists: '/crm/v3/lists',
+            listById: (listId) => `/crm/v3/lists/${listId}`,
             listSearch: '/crm/v3/lists/search',
+            listMembership: (listId) => `/crm/v3/lists/${listId}/memberships/add-and-remove`,
             associations: (fromObject, toObject) => `/crm/v4/associations/${fromObject}/${toObject}`,
             associationLabels: (fromObject, toObject) => `/crm/v4/associations/${fromObject}/${toObject}/labels`,
 
@@ -934,6 +936,36 @@ class Api extends OAuth2Requester {
             },
         };
         return this._post(options);
+    }
+
+    async createList(name, objectTypeId, processingType = 'MANUAL', listFolderId = null) {
+        const options = {
+            url: this.baseUrl + this.URLs.lists,
+            body: {
+                name,
+                objectTypeId,
+                processingType,
+                listFolderId
+            },
+        };
+        return this._post(options);
+    }
+
+    async deleteList(listId) {
+        const options = {
+            url: this.baseUrl + this.URLs.listById(listId),
+        };
+        return this._delete(options);
+    }
+
+    async addToList(listId, recordIds)  {
+        const options = {
+            url: this.baseUrl + this.URLs.listMembership(listId),
+            body: {
+                "recordIdsToAdd": recordIds
+            },
+        };
+        return this._put(options);
     }
 }
 

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -721,7 +721,7 @@ describe(`${config.label} API tests`, () => {
             createdListId = list.listId;
         });
         it('Should get a list', async () => {
-            const response = await api.getList(createdListId);
+            const response = await api.getListById(createdListId);
             expect(response).toBeDefined();
             expect(response.list.listId).toBe(createdListId);
         })

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -1,6 +1,24 @@
 const {Authenticator} = require('@friggframework/test');
 const {Api} = require('../api');
 const config = require('../defaultConfig.json');
+const {promises: fs} = require("fs");
+
+const mockDir = `./mocks${Date.now()}`
+const parsedBody = async function async(resp) {
+    const contentType = resp.headers.get('Content-Type') || '';
+    let body;
+    if (
+        contentType.match(/^application\/json/) ||
+        contentType.match(/^application\/vnd.api\+json/) ||
+        contentType.match(/^application\/hal\+json/)
+    ) {
+        body = await resp.json();
+    } else {
+        body = await resp.text();
+    }
+    await fs.writeFile(`./${mockDir}/${this.lastCalled}.json`, JSON.stringify(body));
+    return body;
+}
 
 describe(`${config.label} API tests`, () => {
 
@@ -11,7 +29,23 @@ describe(`${config.label} API tests`, () => {
         redirect_uri: `${process.env.REDIRECT_URI}/hubspot`,
         scope: process.env.HUBSPOT_SCOPE
     };
+    Object.getOwnPropertyNames(Api.prototype).forEach(f => {
+        if (f !== 'constructor' &&
+            typeof Api.prototype[f] === 'function' &&
+            f !== 'addJsonHeaders' &&
+            !f.startsWith('_')) {
+            const old = Api.prototype[f];
+            Api.prototype[f] = function (...args) {
+                this.lastCalled = f;
+                return old.apply(this, args);
+            }
+        }
+    })
     const api = new Api(apiParams);
+    api.parsedBody = parsedBody;
+    beforeAll(async () => {
+        await fs.mkdir(mockDir, {recursive: true});
+    });
 
     beforeAll(async () => {
         const url = await api.getAuthUri();
@@ -463,6 +497,55 @@ describe(`${config.label} API tests`, () => {
         });
     });
 
+    describe.only('Custom Object Schemas', () => {
+        const testSchema = {
+            "labels": {"singular": "Test Object", "plural": "Test Objects"},
+            "requiredProperties": ["word"],
+            "searchableProperties": ["word"],
+            "primaryDisplayProperty": "word",
+            "secondaryDisplayProperties": [],
+            "description": null,
+            "properties": [{
+                "name": "word",
+                "label": "Word",
+                "type": "string",
+                "fieldType": "text",
+                "description": "",
+                "hasUniqueValue": false
+            }],
+            "associatedObjects": [
+                "COMPANY"
+            ],
+            "name": "test_object"
+        }
+
+        it('should return the Custom Object Schemas', async () => {
+            const response = await api.listCustomObjectSchemas();
+            expect(response).toBeDefined();
+            expect(response).toHaveProperty('results');
+            expect(response.results.length).toBeGreaterThan(0);
+            expect(response.results.filter(s => s.name === testSchema.name).length).toBe(0);
+        });
+
+        it('should create a Custom Object Schema', async () => {
+            const response = await api.createCustomObjectSchema(testSchema);
+            expect(response).toBeDefined();
+            expect(response).toHaveProperty('id');
+        });
+
+        it('Should get association labels', async () => {
+            const labels = await api.getAssociationLabels('COMPANY', testSchema.name);
+            expect(labels).toBeDefined();
+            expect(labels.results).toHaveProperty('length');
+            expect(labels.results.find(label => label.label === 'Primary')).toBeTruthy();
+        })
+
+        it('should delete a Custom Object Schema', async () => {
+            const response = await api.deleteCustomObjectSchema(testSchema.name);
+            expect(response.status).toBe(204);
+        })
+    })
+
     describe('HS Custom Objects', () => {
         let allCustomObjects;
         const testObjType = 'tests';
@@ -626,17 +709,35 @@ describe(`${config.label} API tests`, () => {
         })
     })
 
-    describe('HS List Search', () => {
+    describe.only('HS List Requests', () => {
         it('Should get a list of lists', async () => {
             const response = await api.searchLists();
             expect(response).toBeDefined();
             expect(response.lists).toHaveProperty('length');
+        });
+        let createdListId;
+        it('Should create a list', async () => {
+            const {list} = await api.createList('Test List', '0-2');
+            createdListId = list.listId;
+        });
+        it('Should add a record to list', async () => {
+            const companyResponse = await api.listCompanies();
+            const someCompanyId = companyResponse.results[0].id;
+            const response = await api.addToList(createdListId, [someCompanyId]);
+            expect(response).toBeDefined();
+            // HS has a typo in the response "recordsIds" instead of "recordIds"
+            expect(response.recordsIdsAdded).toHaveLength(1);
+        })
+        it('Should delete a list', async () => {
+            const response = await api.deleteList(createdListId);
+            expect(response).toBeDefined();
+            expect(response.status).toBe(204);
         })
     });
 
-    describe('Association Labels', () => {
+    describe.only('Association Labels', () => {
         it('Should get association labels', async () => {
-            const labels = await api.getAssociationLabels('CONTACT', 'COMPANY');
+            const labels = await api.getAssociationLabels('COMPANY', 'fourtytwomattersappdata');
             expect(labels).toBeDefined();
             expect(labels.results).toHaveProperty('length');
             expect(labels.results.find(label => label.label === 'Primary')).toBeTruthy();

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -737,7 +737,7 @@ describe(`${config.label} API tests`, () => {
 
     describe.only('Association Labels', () => {
         it('Should get association labels', async () => {
-            const labels = await api.getAssociationLabels('COMPANY', 'fourtytwomattersappdata');
+            const labels = await api.getAssociationLabels('COMPANY', 'CONTACT');
             expect(labels).toBeDefined();
             expect(labels.results).toHaveProperty('length');
             expect(labels.results.find(label => label.label === 'Primary')).toBeTruthy();

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -497,7 +497,7 @@ describe(`${config.label} API tests`, () => {
         });
     });
 
-    describe.only('Custom Object Schemas', () => {
+    describe('Custom Object Schemas', () => {
         const testSchema = {
             "labels": {"singular": "Test Object", "plural": "Test Objects"},
             "requiredProperties": ["word"],
@@ -709,7 +709,7 @@ describe(`${config.label} API tests`, () => {
         })
     })
 
-    describe.only('HS List Requests', () => {
+    describe('HS List Requests', () => {
         it('Should get a list of lists', async () => {
             const response = await api.searchLists();
             expect(response).toBeDefined();
@@ -740,7 +740,7 @@ describe(`${config.label} API tests`, () => {
         })
     });
 
-    describe.only('Association Labels', () => {
+    describe('Association Labels', () => {
         it('Should get association labels', async () => {
             const labels = await api.getAssociationLabels('COMPANY', 'CONTACT');
             expect(labels).toBeDefined();

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -720,6 +720,11 @@ describe(`${config.label} API tests`, () => {
             const {list} = await api.createList('Test List', '0-2');
             createdListId = list.listId;
         });
+        it('Should get a list', async () => {
+            const response = await api.getList(createdListId);
+            expect(response).toBeDefined();
+            expect(response.list.listId).toBe(createdListId);
+        })
         it('Should add a record to list', async () => {
             const companyResponse = await api.listCompanies();
             const someCompanyId = companyResponse.results[0].id;


### PR DESCRIPTION
Add tests for same
I've included a prototype for generating mocks from api tests, but it maybe shouldn't be included here. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-hubspot@1.1.3-canary.3.601e4d2.0
  # or 
  yarn add @friggframework/api-module-hubspot@1.1.3-canary.3.601e4d2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
