### PR TITLE
HubSpot API Method Updates

### DIFF
--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -33,6 +33,8 @@ class Api extends OAuth2Requester {
             createBatchAssociationsDefault: (fromObjectType, toObjectType) =>
                 `/crm/v4/associations/${fromObjectType}/${toObjectType}/batch/associate/default`,
             deleteBatchAssociations: (fromObjectType, toObjectType) =>
+                `/crm/v4/associations/${fromObjectType}/${toObjectType}/batch/archive`,
+            deleteBatchAssociationLabels: (fromObjectType, toObjectType) =>
                 `/crm/v4/associations/${fromObjectType}/${toObjectType}/batch/labels/archive`,
             v1DealInfo: (dealId) => `/deals/v1/deal/${dealId}`,
             getPipelineDetails: (objType) => `/crm/v3/pipelines/${objType}`,
@@ -944,6 +946,18 @@ class Api extends OAuth2Requester {
             url:
                 this.baseUrl +
                 this.URLs.deleteBatchAssociations(fromObjectType, toObjectType),
+            body: {inputs},
+            returnFullRes: true,
+        };
+
+        return this._post(options);
+    }
+
+    async deleteBatchAssociationLabels(fromObjectType, toObjectType, inputs) {
+        const options = {
+            url:
+                this.baseUrl +
+                this.URLs.deleteBatchAssociationLabels(fromObjectType, toObjectType),
             body: {inputs},
             returnFullRes: true,
         };

--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -662,7 +662,7 @@ class Api extends OAuth2Requester {
     async updateProperty(objType, propName, body) {
         const options = {
             url: this.baseUrl + this.URLs.propertiesByName(objType, propName),
-            body,
+            body: {body},
         };
         return this._patch(options);
     }

--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -26,8 +26,14 @@ class Api extends OAuth2Requester {
             deals: '/crm/v3/objects/deals',
             dealById: (dealId) => `/crm/v3/objects/deals/${dealId}`,
             searchDeals: '/crm/v3/objects/deals/search',
-            getBatchAssociations: (fromObject, toObject) =>
-                `/crm/v3/associations/${fromObject}/${toObject}/batch/read`,
+            readBatchAssociations: (fromObject, toObject) =>
+                `/crm/v4/associations/${fromObject}/${toObject}/batch/read`,
+            createBatchAssociations: (fromObject, toObject) =>
+                `/crm/v4/associations/${fromObject}/${toObject}/batch/create`,
+            createBatchAssociationsDefault: (fromObject, toObject) =>
+                `/crm/v4/associations/${fromObject}/${toObject}/batch/associate/default`,
+            deleteBatchAssociations: (fromObject, toObject) =>
+                `/crm/v4/associations/${fromObject}/${toObject}/batch/labels/archive`,
             v1DealInfo: (dealId) => `/deals/v1/deal/${dealId}`,
             getPipelineDetails: (objType) => `/crm/v3/pipelines/${objType}`,
             getOwnerById: (ownerId) => `/owners/v2/owners/${ownerId}`,
@@ -889,23 +895,59 @@ class Api extends OAuth2Requester {
         return this._get(options);
     }
 
-    async batchGetAssociations(params) {
-        const fromObject = get(params, 'fromObject');
-        const toObject = get(params, 'toObject');
-        const inputs = get(params, 'inputs');
-
+    async getBatchAssociations(fromObject, toObject, inputs) {
         const postBody = {inputs};
 
         const options = {
             url:
                 this.baseUrl +
-                this.URLs.getBatchAssociations(fromObject, toObject),
+                this.URLs.readBatchAssociations(fromObject, toObject),
             body: postBody,
         };
 
         const res = await this._post(options);
         const {results} = res;
         return results;
+    }
+
+    async createBatchAssociations(fromObject, toObject, inputs) {
+        const postBody = {inputs};
+
+        const options = {
+            url:
+                this.baseUrl +
+                this.URLs.createBatchAssociations(fromObject, toObject),
+            body: postBody,
+        };
+
+        const res = await this._post(options);
+        const {results} = res;
+        return results;
+    }
+
+    async createBatchAssociationsDefault(fromObject, toObject, inputs) {
+        const options = {
+            url:
+                this.baseUrl +
+                this.URLs.createBatchAssociationsDefault(fromObject, toObject),
+            body: {inputs},
+        };
+
+        const res = await this._post(options);
+        const {results} = res;
+        return results;
+    }
+
+    async deleteBatchAssociations(fromObject, toObject, inputs) {
+        const options = {
+            url:
+                this.baseUrl +
+                this.URLs.deleteBatchAssociations(fromObject, toObject),
+            body: {inputs},
+            returnFullRes: true,
+        };
+
+        return this._post(options);
     }
 
     async _propertiesList(objType) {
@@ -923,6 +965,21 @@ class Api extends OAuth2Requester {
             url: this.baseUrl + this.URLs.associationLabels(fromObjType, toObjType),
         };
         return this._get(options);
+    }
+
+    async createAssociationLabel(fromObjType, toObjType, label) {
+        const options = {
+            url: this.baseUrl + this.URLs.associationLabels(fromObjType, toObjType),
+            body: label
+        };
+        return this._post(options);
+    }
+
+    async deleteAssociationLabel(fromObjType, toObjType, associationTypeId) {
+        const options = {
+            url: this.baseUrl + this.URLs.associationLabels(fromObjType, toObjType) + `/${associationTypeId}`,
+        };
+        return this._delete(options, false);
     }
 
     async searchLists(query = "", offset = 0, count = 500, additionalProperties = []) {

--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -662,7 +662,7 @@ class Api extends OAuth2Requester {
     async updateProperty(objType, propName, body) {
         const options = {
             url: this.baseUrl + this.URLs.propertiesByName(objType, propName),
-            body: {body},
+            body,
         };
         return this._patch(options);
     }

--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -65,7 +65,8 @@ class Api extends OAuth2Requester {
             lists: '/crm/v3/lists',
             listById: (listId) => `/crm/v3/lists/${listId}`,
             listSearch: '/crm/v3/lists/search',
-            listMembership: (listId) => `/crm/v3/lists/${listId}/memberships/add-and-remove`,
+            listMemberships: (listId) => `/crm/v3/lists/${listId}/memberships`,
+            listMembershipsAddRemove: (listId) => `/crm/v3/lists/${listId}/memberships/add-and-remove`,
             associations: (fromObject, toObject) => `/crm/v4/associations/${fromObject}/${toObject}`,
             associationLabels: (fromObject, toObject) => `/crm/v4/associations/${fromObject}/${toObject}/labels`,
 
@@ -1022,15 +1023,33 @@ class Api extends OAuth2Requester {
         return this._delete(options);
     }
 
-    async addToList(listId, recordIds)  {
+    async removeAllListMembers(listId) {
         const options = {
-            url: this.baseUrl + this.URLs.listMembership(listId),
+            url: this.baseUrl + this.URLs.listMemberships(listId),
+        };
+        return this._delete(options);
+    }
+
+    async addAndRemoveFromList(listId, idsToAdd, idsToRemove)  {
+        const options = {
+            url: this.baseUrl + this.URLs.listMembershipsAddRemove(listId),
             body: {
-                "recordIdsToAdd": recordIds
+                "recordIdsToAdd": idsToAdd,
+                "recordIdsToRemove": idsToRemove
             },
         };
         return this._put(options);
     }
+
+    async addToList(listId, recordIds)  {
+        return this.addAndRemoveFromList(listId, recordIds, []);
+    }
+
+    async removeFromList(listId, recordIds)  {
+        return this.addAndRemoveFromList(listId, [], recordIds);
+    }
+
+
 }
 
 module.exports = {Api};

--- a/packages/hubspot/api.js
+++ b/packages/hubspot/api.js
@@ -26,14 +26,14 @@ class Api extends OAuth2Requester {
             deals: '/crm/v3/objects/deals',
             dealById: (dealId) => `/crm/v3/objects/deals/${dealId}`,
             searchDeals: '/crm/v3/objects/deals/search',
-            readBatchAssociations: (fromObject, toObject) =>
-                `/crm/v4/associations/${fromObject}/${toObject}/batch/read`,
-            createBatchAssociations: (fromObject, toObject) =>
-                `/crm/v4/associations/${fromObject}/${toObject}/batch/create`,
-            createBatchAssociationsDefault: (fromObject, toObject) =>
-                `/crm/v4/associations/${fromObject}/${toObject}/batch/associate/default`,
-            deleteBatchAssociations: (fromObject, toObject) =>
-                `/crm/v4/associations/${fromObject}/${toObject}/batch/labels/archive`,
+            readBatchAssociations: (fromObjectType, toObjectType) =>
+                `/crm/v4/associations/${fromObjectType}/${toObjectType}/batch/read`,
+            createBatchAssociations: (fromObjectType, toObjectType) =>
+                `/crm/v4/associations/${fromObjectType}/${toObjectType}/batch/create`,
+            createBatchAssociationsDefault: (fromObjectType, toObjectType) =>
+                `/crm/v4/associations/${fromObjectType}/${toObjectType}/batch/associate/default`,
+            deleteBatchAssociations: (fromObjectType, toObjectType) =>
+                `/crm/v4/associations/${fromObjectType}/${toObjectType}/batch/labels/archive`,
             v1DealInfo: (dealId) => `/deals/v1/deal/${dealId}`,
             getPipelineDetails: (objType) => `/crm/v3/pipelines/${objType}`,
             getOwnerById: (ownerId) => `/owners/v2/owners/${ownerId}`,
@@ -896,13 +896,13 @@ class Api extends OAuth2Requester {
         return this._get(options);
     }
 
-    async getBatchAssociations(fromObject, toObject, inputs) {
+    async getBatchAssociations(fromObjectType, toObjectType, inputs) {
         const postBody = {inputs};
 
         const options = {
             url:
                 this.baseUrl +
-                this.URLs.readBatchAssociations(fromObject, toObject),
+                this.URLs.readBatchAssociations(fromObjectType, toObjectType),
             body: postBody,
         };
 
@@ -911,13 +911,13 @@ class Api extends OAuth2Requester {
         return results;
     }
 
-    async createBatchAssociations(fromObject, toObject, inputs) {
+    async createBatchAssociations(fromObjectType, toObjectType, inputs) {
         const postBody = {inputs};
 
         const options = {
             url:
                 this.baseUrl +
-                this.URLs.createBatchAssociations(fromObject, toObject),
+                this.URLs.createBatchAssociations(fromObjectType, toObjectType),
             body: postBody,
         };
 
@@ -926,11 +926,11 @@ class Api extends OAuth2Requester {
         return results;
     }
 
-    async createBatchAssociationsDefault(fromObject, toObject, inputs) {
+    async createBatchAssociationsDefault(fromObjectType, toObjectType, inputs) {
         const options = {
             url:
                 this.baseUrl +
-                this.URLs.createBatchAssociationsDefault(fromObject, toObject),
+                this.URLs.createBatchAssociationsDefault(fromObjectType, toObjectType),
             body: {inputs},
         };
 
@@ -939,11 +939,11 @@ class Api extends OAuth2Requester {
         return results;
     }
 
-    async deleteBatchAssociations(fromObject, toObject, inputs) {
+    async deleteBatchAssociations(fromObjectType, toObjectType, inputs) {
         const options = {
             url:
                 this.baseUrl +
-                this.URLs.deleteBatchAssociations(fromObject, toObject),
+                this.URLs.deleteBatchAssociations(fromObjectType, toObjectType),
             body: {inputs},
             returnFullRes: true,
         };

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -929,8 +929,6 @@ describe(`${config.label} API tests`, () => {
                 {
                     "label": "Item Three",
                     "value": "item_three",
-                    displayOrder: 2,
-                    hidden: false
                 }
             )
             const response = await api.updateProperty('tests', 'test_field', existing);

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -708,7 +708,7 @@ describe(`${config.label} API tests`, () => {
         })
     })
 
-    describe('HS List Requests', () => {
+    describe.only('HS List Requests', () => {
         it('Should get a list of lists', async () => {
             const response = await api.searchLists();
             expect(response).toBeDefined();
@@ -731,6 +731,10 @@ describe(`${config.label} API tests`, () => {
             expect(response).toBeDefined();
             // HS has a typo in the response "recordsIds" instead of "recordIds"
             expect(response.recordsIdsAdded).toHaveLength(1);
+        })
+        it('Should remove all records from list', async () => {
+            const response = await api.removeAllListMembers(createdListId);
+            expect(response.status).toBe(204);
         })
         it('Should delete a list', async () => {
             const response = await api.deleteList(createdListId);

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -739,7 +739,7 @@ describe(`${config.label} API tests`, () => {
         })
     });
 
-    describe.only('Association Labels', () => {
+    describe('Association Labels', () => {
         it('Should get association labels', async () => {
             const labels = await api.getAssociationLabels('COMPANY', 'CONTACT');
             expect(labels).toBeDefined();
@@ -772,7 +772,7 @@ describe(`${config.label} API tests`, () => {
         it('Should create batch default associations', async () => {
             const inputs = createdBatch.map(o => {
                 return {
-                    from:{id:  o.id},
+                    from: {id: o.id},
                     to: {id: toCompany}
                 }
             });
@@ -783,7 +783,7 @@ describe(`${config.label} API tests`, () => {
             );
             expect(response).toBeDefined();
             expect(response).toHaveProperty('length');
-            expect(response.length).toBe(createdBatch.length*2);
+            expect(response.length).toBe(createdBatch.length * 2);
         })
 
         let createdLabel;
@@ -802,7 +802,7 @@ describe(`${config.label} API tests`, () => {
         })
 
         it('Should get association labels', async () => {
-            const labels = await api.getAssociationLabels(testObjType,'COMPANY');
+            const labels = await api.getAssociationLabels(testObjType, 'COMPANY');
             expect(labels).toBeDefined();
             expect(labels.results).toHaveProperty('length');
             expect(labels.results.find(label => label.label && label.label === 'Foo')).toBeTruthy();
@@ -817,7 +817,7 @@ describe(`${config.label} API tests`, () => {
                         associationCategory: createdLabel.category,
                         associationTypeId: createdLabel.typeId
                     }],
-                    from:{id:  o.id},
+                    from: {id: o.id},
                     to: {id: toCompany}
                 }
             });
@@ -855,7 +855,7 @@ describe(`${config.label} API tests`, () => {
                         associationCategory: createdLabel.category,
                         associationTypeId: createdLabel.typeId
                     }],
-                    from:{id:  o.id},
+                    from: {id: o.id},
                     to: {id: toCompany}
                 }
             });
@@ -887,6 +887,63 @@ describe(`${config.label} API tests`, () => {
             expect(response).toBeDefined();
             expect(response).toBe("");
         });
+    });
+
+    describe.only('Properties requests', () => {
+        let groupeName;
+        it('Should retrieve a property', async () => {
+            const response = await api.getPropertyByName('tests', 'word');
+            expect(response).toBeDefined();
+            expect(response).toHaveProperty('label');
+            expect(response.label).toBe('Word');
+            groupeName = response.groupName;
+        });
+
+        it('Should create a property', async () => {
+            const response = await api.createProperty('tests', {
+                "name": "test_field",
+                "label": "Test Field",
+                "type": "enumeration",
+                "fieldType": "select",
+                "groupName": groupeName,
+                "description": "A test of enumerated fields",
+                "options": [
+                    {
+                        "label": "Item One",
+                        "value": "item_one"
+                    },
+                    {
+                        "label": "Item Two",
+                        "value": "item_two"
+                    }
+                ]
+            });
+            expect(response).toBeDefined();
+            expect(response).toHaveProperty('label');
+            expect(response.name).toBe('test_field');
+        });
+
+        it('Should update a property', async () => {
+            const existing = await api.getPropertyByName('tests', 'test_field');
+            existing.options.push(
+                {
+                    "label": "Item Three",
+                    "value": "item_three",
+                    displayOrder: 2,
+                    hidden: false
+                }
+            )
+            const response = await api.updateProperty('tests', 'test_field', existing);
+            expect(response).toBeDefined();
+            expect(response).toHaveProperty('options');
+            expect(response.options.some(o => o.label === 'Item Three')).toBeTruthy();
+        });
+
+        it('Should delete a property', async () => {
+            const response = await api.deleteProperty('tests', 'test_field');
+            expect(response).toBeDefined();
+            expect(response.status).toBe(204);
+        })
 
     })
 });

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -863,7 +863,7 @@ describe(`${config.label} API tests`, () => {
                     to: {id: toCompany}
                 }
             });
-            const response = await api.deleteBatchAssociations(
+            const response = await api.deleteBatchAssociationLabels(
                 testObjType,
                 'COMPANY',
                 inputs

--- a/packages/hubspot/tests/api.test.js
+++ b/packages/hubspot/tests/api.test.js
@@ -708,7 +708,7 @@ describe(`${config.label} API tests`, () => {
         })
     })
 
-    describe.only('HS List Requests', () => {
+    describe('HS List Requests', () => {
         it('Should get a list of lists', async () => {
             const response = await api.searchLists();
             expect(response).toBeDefined();
@@ -893,7 +893,7 @@ describe(`${config.label} API tests`, () => {
         });
     });
 
-    describe.only('Properties requests', () => {
+    describe('Properties requests', () => {
         let groupeName;
         it('Should retrieve a property', async () => {
             const response = await api.getPropertyByName('tests', 'word');


### PR DESCRIPTION
Property, Association and Association Label requests
Test coverage for same
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-hubspot@1.1.5-canary.5.59bbff2.0
  # or 
  yarn add @friggframework/api-module-hubspot@1.1.5-canary.5.59bbff2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
