### PR TITLE
Bumped to core-next to resolve use-source-map issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2562,6 +2562,10 @@
       "resolved": "packages/v1-ready/asana",
       "link": true
     },
+    "node_modules/@friggframework/api-module-attio": {
+      "resolved": "packages/v1-ready/attio",
+      "link": true
+    },
     "node_modules/@friggframework/api-module-connectwise": {
       "resolved": "packages/v1-ready/connectwise",
       "link": true
@@ -6811,6 +6815,13 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.147",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.147.tgz",
+      "integrity": "sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -9580,6 +9591,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.0",
@@ -12565,7 +12589,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -16284,7 +16307,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -19369,6 +19391,15 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
@@ -21358,6 +21389,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/serverless-http": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-2.7.0.tgz",
+      "integrity": "sha512-iWq0z1X2Xkuvz6wL305uCux/SypbojHlYsB5bzmF5TqoLYsdvMNIoCsgtWjwqWoo3AR2cjw3zAmHN2+U6mF99Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      },
+      "optionalDependencies": {
+        "@types/aws-lambda": "^8.10.56"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -22946,7 +22989,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -25033,7 +25075,7 @@
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "@friggframework/core": "^1.1.2"
+        "@friggframework/core": "^2.0.0-next.16"
       },
       "devDependencies": {
         "@friggframework/devtools": "^1.1.2",
@@ -25043,6 +25085,29 @@
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
         "prettier": "^2.7.1"
+      }
+    },
+    "packages/v1-ready/asana/node_modules/@friggframework/core": {
+      "version": "2.0.0-next.16",
+      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.16.tgz",
+      "integrity": "sha512-rF6Qq+PGK61S529/HogruZIclT5kjwSzm+vGOPUFFbtVYtTrjlV/2Ha4RK9lYYOtJjVvD0Bng53NITCyOYaBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "aws-sdk": "^2.1200.0",
+        "bcryptjs": "^2.4.3",
+        "body-parser": "^1.20.2",
+        "common-tags": "^1.8.2",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "express-async-handler": "^1.2.0",
+        "form-data": "^4.0.0",
+        "fs-extra": "^11.2.0",
+        "lodash": "4.17.21",
+        "mongoose": "6.11.6",
+        "node-fetch": "^2.6.7",
+        "serverless-http": "^2.7.0",
+        "uuid": "^9.0.1"
       }
     },
     "packages/v1-ready/asana/node_modules/dotenv": {
@@ -25056,6 +25121,177 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "packages/v1-ready/asana/node_modules/mongodb": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
+      }
+    },
+    "packages/v1-ready/asana/node_modules/mongoose": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.6.tgz",
+      "integrity": "sha512-CuVbeJrEbnxkPUNNFvXJhjVyqa5Ip7lkz6EJX6g7Lb3aFMTJ+LHOlUrncxzC3r20dqasaVIiwcA6Y5qC8PWQ7w==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "kareem": "2.5.1",
+        "mongodb": "4.16.0",
+        "mpath": "0.9.0",
+        "mquery": "4.0.3",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "packages/v1-ready/asana/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "packages/v1-ready/asana/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/v1-ready/attio": {
+      "name": "@friggframework/api-module-attio",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@friggframework/core": "^2.0.0-next.16"
+      },
+      "devDependencies": {
+        "@friggframework/devtools": "^1.1.2",
+        "@friggframework/test": "^1.1.2",
+        "dotenv": "^16.0.3",
+        "eslint": "^8.22.0",
+        "jest": "^28.1.3",
+        "jest-environment-jsdom": "^28.1.3",
+        "prettier": "^2.7.1"
+      }
+    },
+    "packages/v1-ready/attio/node_modules/@friggframework/core": {
+      "version": "2.0.0-next.16",
+      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.16.tgz",
+      "integrity": "sha512-rF6Qq+PGK61S529/HogruZIclT5kjwSzm+vGOPUFFbtVYtTrjlV/2Ha4RK9lYYOtJjVvD0Bng53NITCyOYaBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "aws-sdk": "^2.1200.0",
+        "bcryptjs": "^2.4.3",
+        "body-parser": "^1.20.2",
+        "common-tags": "^1.8.2",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "express-async-handler": "^1.2.0",
+        "form-data": "^4.0.0",
+        "fs-extra": "^11.2.0",
+        "lodash": "4.17.21",
+        "mongoose": "6.11.6",
+        "node-fetch": "^2.6.7",
+        "serverless-http": "^2.7.0",
+        "uuid": "^9.0.1"
+      }
+    },
+    "packages/v1-ready/attio/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "packages/v1-ready/attio/node_modules/mongodb": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
+      }
+    },
+    "packages/v1-ready/attio/node_modules/mongoose": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.6.tgz",
+      "integrity": "sha512-CuVbeJrEbnxkPUNNFvXJhjVyqa5Ip7lkz6EJX6g7Lb3aFMTJ+LHOlUrncxzC3r20dqasaVIiwcA6Y5qC8PWQ7w==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "kareem": "2.5.1",
+        "mongodb": "4.16.0",
+        "mpath": "0.9.0",
+        "mquery": "4.0.3",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "packages/v1-ready/attio/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "packages/v1-ready/attio/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/v1-ready/connectwise": {
@@ -29518,7 +29754,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@friggframework/core": "^2.0.0-next.5"
+        "@friggframework/core": "^2.0.0-next.16"
       },
       "devDependencies": {
         "dotenv": "^16.3.1",
@@ -29529,21 +29765,26 @@
       }
     },
     "packages/v1-ready/frontify/node_modules/@friggframework/core": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.5.tgz",
-      "integrity": "sha512-4SORpXon0CEAAt29PGlU/IkZaHGIVoGFVcJuiSYpy9uBvBjRzfSrJWPCop12m7VpOAEGQKUs0ZCbpQLXi5J3xg==",
+      "version": "2.0.0-next.16",
+      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.16.tgz",
+      "integrity": "sha512-rF6Qq+PGK61S529/HogruZIclT5kjwSzm+vGOPUFFbtVYtTrjlV/2Ha4RK9lYYOtJjVvD0Bng53NITCyOYaBgw==",
       "license": "MIT",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "aws-sdk": "^2.1200.0",
         "bcryptjs": "^2.4.3",
+        "body-parser": "^1.20.2",
         "common-tags": "^1.8.2",
-        "express": "^4.18.2",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
         "express-async-handler": "^1.2.0",
-        "lodash": "^4.17.21",
-        "lodash.get": "^4.4.2",
+        "form-data": "^4.0.0",
+        "fs-extra": "^11.2.0",
+        "lodash": "4.17.21",
         "mongoose": "6.11.6",
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.7",
+        "serverless-http": "^2.7.0",
+        "uuid": "^9.0.1"
       }
     },
     "packages/v1-ready/frontify/node_modules/@jest/console": {
@@ -30646,6 +30887,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/v1-ready/frontify/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/v1-ready/frontify/node_modules/y18n": {
@@ -33971,7 +34225,7 @@
       "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
-        "@friggframework/core": "^1.1.2"
+        "@friggframework/core": "^2.0.0-next.16"
       },
       "devDependencies": {
         "@friggframework/devtools": "^1.1.2",
@@ -33981,6 +34235,29 @@
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
         "prettier": "^2.7.1"
+      }
+    },
+    "packages/v1-ready/hubspot/node_modules/@friggframework/core": {
+      "version": "2.0.0-next.16",
+      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.16.tgz",
+      "integrity": "sha512-rF6Qq+PGK61S529/HogruZIclT5kjwSzm+vGOPUFFbtVYtTrjlV/2Ha4RK9lYYOtJjVvD0Bng53NITCyOYaBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "aws-sdk": "^2.1200.0",
+        "bcryptjs": "^2.4.3",
+        "body-parser": "^1.20.2",
+        "common-tags": "^1.8.2",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "express-async-handler": "^1.2.0",
+        "form-data": "^4.0.0",
+        "fs-extra": "^11.2.0",
+        "lodash": "4.17.21",
+        "mongoose": "6.11.6",
+        "node-fetch": "^2.6.7",
+        "serverless-http": "^2.7.0",
+        "uuid": "^9.0.1"
       }
     },
     "packages/v1-ready/hubspot/node_modules/dotenv": {
@@ -33994,6 +34271,65 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "packages/v1-ready/hubspot/node_modules/mongodb": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
+      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.5.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "saslprep": "^1.0.3"
+      }
+    },
+    "packages/v1-ready/hubspot/node_modules/mongoose": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.6.tgz",
+      "integrity": "sha512-CuVbeJrEbnxkPUNNFvXJhjVyqa5Ip7lkz6EJX6g7Lb3aFMTJ+LHOlUrncxzC3r20dqasaVIiwcA6Y5qC8PWQ7w==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^4.7.2",
+        "kareem": "2.5.1",
+        "mongodb": "4.16.0",
+        "mpath": "0.9.0",
+        "mquery": "4.0.3",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "packages/v1-ready/hubspot/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "packages/v1-ready/hubspot/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/v1-ready/ironclad": {

--- a/packages/v1-ready/asana/package.json
+++ b/packages/v1-ready/asana/package.json
@@ -20,7 +20,7 @@
     "prettier": "^2.7.1"
   },
   "dependencies": {
-    "@friggframework/core": "^1.1.2"
+    "@friggframework/core": "^2.0.0-next.16"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/v1-ready/attio/.env.example
+++ b/packages/v1-ready/attio/.env.example
@@ -1,0 +1,4 @@
+ATTIO_CLIENT_ID=your_client_id_here
+ATTIO_CLIENT_SECRET=your_client_secret_here
+ATTIO_SCOPE=read:objects write:objects read:records write:records read:workspaces read:lists
+REDIRECT_URI=http://localhost:3000/oauth/callback 

--- a/packages/v1-ready/attio/README.md
+++ b/packages/v1-ready/attio/README.md
@@ -1,0 +1,48 @@
+# @friggframework/api-module-attio
+
+This module integrates Attio into the Frigg Framework, providing access to Attio's API functionality.
+
+## Features
+
+- OAuth2 authentication
+- Access to Attio's API endpoints
+- Support for objects, records, attributes, workspaces, and lists management
+- Search functionality
+
+## Installation
+
+```bash
+npm install @friggframework/api-module-attio
+```
+
+## Configuration
+
+The module requires the following environment variables:
+
+```env
+ATTIO_CLIENT_ID=your_client_id
+ATTIO_CLIENT_SECRET=your_client_secret
+ATTIO_SCOPE=your_scopes
+REDIRECT_URI=your_redirect_uri
+```
+
+## Usage
+
+```javascript
+const {Api, Definition} = require('@friggframework/api-module-attio');
+
+// Initialize the API
+const api = new Api({
+    client_id: process.env.ATTIO_CLIENT_ID,
+    client_secret: process.env.ATTIO_CLIENT_SECRET,
+    scope: process.env.ATTIO_SCOPE,
+    redirect_uri: process.env.REDIRECT_URI
+});
+
+// Example: List objects
+const objects = await api.listObjects();
+```
+
+## License
+
+MIT 

--- a/packages/v1-ready/attio/api.js
+++ b/packages/v1-ready/attio/api.js
@@ -1,0 +1,154 @@
+const {OAuth2Requester} = require('@friggframework/core');
+
+class Api extends OAuth2Requester {
+    constructor(params) {
+        super(params);
+        this.baseUrl = 'https://api.attio.com/v2';
+        
+        this.URLs = {
+            authorization: '/oauth/authorize',
+            access_token: '/oauth/token',
+            userDetails: '/auth/me',
+            objects: '/objects',
+            objectById: (objectId) => `/objects/${objectId}`,
+            records: (objectId) => `/objects/${objectId}/records`,
+            recordById: (objectId, recordId) => `/objects/${objectId}/records/${recordId}`,
+            search: (objectId) => `/objects/${objectId}/records/search`,
+            attributes: (objectId) => `/objects/${objectId}/attributes`,
+            attributeById: (objectId, attributeId) => `/objects/${objectId}/attributes/${attributeId}`,
+            workspaces: '/workspaces',
+            workspaceById: (workspaceId) => `/workspaces/${workspaceId}`,
+            lists: '/lists',
+            listById: (listId) => `/lists/${listId}`,
+            listRecords: (listId) => `/lists/${listId}/records`,
+        };
+    }
+
+    async getUserDetails() {
+        const options = {
+            url: this.baseUrl + this.URLs.userDetails,
+        };
+        return this.get(options);
+    }
+
+    async listObjects() {
+        const options = {
+            url: this.baseUrl + this.URLs.objects,
+        };
+        return this.get(options);
+    }
+
+    async getObject(objectId) {
+        const options = {
+            url: this.baseUrl + this.URLs.objectById(objectId),
+        };
+        return this.get(options);
+    }
+
+    async listRecords(objectId, params = {}) {
+        const options = {
+            url: this.baseUrl + this.URLs.records(objectId),
+            params,
+        };
+        return this.get(options);
+    }
+
+    async getRecord(objectId, recordId) {
+        const options = {
+            url: this.baseUrl + this.URLs.recordById(objectId, recordId),
+        };
+        return this.get(options);
+    }
+
+    async createRecord(objectId, data) {
+        const options = {
+            url: this.baseUrl + this.URLs.records(objectId),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: data,
+        };
+        return this.post(options);
+    }
+
+    async updateRecord(objectId, recordId, data) {
+        const options = {
+            url: this.baseUrl + this.URLs.recordById(objectId, recordId),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: data,
+        };
+        return this.patch(options);
+    }
+
+    async deleteRecord(objectId, recordId) {
+        const options = {
+            url: this.baseUrl + this.URLs.recordById(objectId, recordId),
+        };
+        return this.delete(options);
+    }
+
+    async searchRecords(objectId, query) {
+        const options = {
+            url: this.baseUrl + this.URLs.search(objectId),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: query,
+        };
+        return this.post(options);
+    }
+
+    async listAttributes(objectId) {
+        const options = {
+            url: this.baseUrl + this.URLs.attributes(objectId),
+        };
+        return this.get(options);
+    }
+
+    async getAttribute(objectId, attributeId) {
+        const options = {
+            url: this.baseUrl + this.URLs.attributeById(objectId, attributeId),
+        };
+        return this.get(options);
+    }
+
+    async listWorkspaces() {
+        const options = {
+            url: this.baseUrl + this.URLs.workspaces,
+        };
+        return this.get(options);
+    }
+
+    async getWorkspace(workspaceId) {
+        const options = {
+            url: this.baseUrl + this.URLs.workspaceById(workspaceId),
+        };
+        return this.get(options);
+    }
+
+    async listLists() {
+        const options = {
+            url: this.baseUrl + this.URLs.lists,
+        };
+        return this.get(options);
+    }
+
+    async getList(listId) {
+        const options = {
+            url: this.baseUrl + this.URLs.listById(listId),
+        };
+        return this.get(options);
+    }
+
+    async getListRecords(listId, params = {}) {
+        const options = {
+            url: this.baseUrl + this.URLs.listRecords(listId),
+            params,
+        };
+        return this.get(options);
+    }
+}
+
+module.exports = {Api}; 

--- a/packages/v1-ready/attio/defaultConfig.json
+++ b/packages/v1-ready/attio/defaultConfig.json
@@ -1,0 +1,14 @@
+{
+    "name": "attio",
+    "config": {
+        "oauth": true,
+        "batch": {
+            "concurrency": 3,
+            "delay": 1000
+        },
+        "tokenHost": "https://app.attio.com",
+        "tokenPath": "/oauth/token",
+        "authorizeHost": "https://app.attio.com",
+        "authorizePath": "/oauth/authorize"
+    }
+} 

--- a/packages/v1-ready/attio/definition.js
+++ b/packages/v1-ready/attio/definition.js
@@ -1,0 +1,46 @@
+require('dotenv').config();
+const {Api} = require('./api');
+const {get} = require("@friggframework/core");
+const config = require('./defaultConfig.json')
+
+const Definition = {
+    API: Api,
+    getName: () => config.name,
+    moduleName: config.name,
+    modelName: 'Attio',
+    requiredAuthMethods: {
+        getToken: async (api, params) => {
+            const code = get(params.data, 'code');
+            return api.getTokenFromCode(code);
+        },
+        getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: {externalId: userDetails.id, user: userId},
+                details: {name: userDetails.email},
+            }
+        },
+        apiPropertiesToPersist: {
+            credential: [
+                'access_token', 'refresh_token'
+            ],
+            entity: [],
+        },
+        getCredentialDetails: async (api, userId) => {
+            const userDetails = await api.getUserDetails();
+            return {
+                identifiers: {externalId: userDetails.id, user: userId},
+                details: {}
+            };
+        },
+        testAuthRequest: async (api) => api.getUserDetails(),
+    },
+    env: {
+        client_id: process.env.ATTIO_CLIENT_ID,
+        client_secret: process.env.ATTIO_CLIENT_SECRET,
+        scope: process.env.ATTIO_SCOPE,
+        redirect_uri: `${process.env.REDIRECT_URI}/attio`,
+    }
+};
+
+module.exports = {Definition}; 

--- a/packages/v1-ready/attio/index.js
+++ b/packages/v1-ready/attio/index.js
@@ -1,0 +1,7 @@
+const {Api} = require('./api');
+const {Definition} = require('./definition');
+
+module.exports = {
+    Api,
+    Definition,
+}; 

--- a/packages/v1-ready/attio/package.json
+++ b/packages/v1-ready/attio/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@friggframework/api-module-hubspot",
-  "version": "1.1.7",
+  "name": "@friggframework/api-module-attio",
+  "version": "1.0.0",
   "prettier": "@friggframework/prettier-config",
-  "description": "HubSpot API module that lets the Frigg Framework interact with HubSpot",
+  "description": "Attio API module that lets the Frigg Framework interact with Attio",
   "main": "index.js",
   "scripts": {
     "lint:fix": "prettier --write --loglevel error . && eslint . --fix",
@@ -21,5 +21,8 @@
   },
   "dependencies": {
     "@friggframework/core": "^2.0.0-next.16"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/v1-ready/frontify/package.json
+++ b/packages/v1-ready/frontify/package.json
@@ -18,7 +18,7 @@
     "sinon": "^16.0.0"
   },
   "dependencies": {
-    "@friggframework/core": "^2.0.0-next.5"
+    "@friggframework/core": "^2.0.0-next.16"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### TL;DR
Added new Attio API module and updated core dependencies across multiple modules.

### What changed?
- Created new Attio API module with OAuth2 authentication support
- Added API endpoints for managing Attio objects, records, attributes, workspaces, and lists
- Implemented search functionality for Attio records
- Updated @friggframework/core dependency to version 2.0.0-next.16 for Asana, Frontify, and Hubspot modules

### How to test?
1. Configure environment variables in `.env`:
```
ATTIO_CLIENT_ID=your_client_id_here
ATTIO_CLIENT_SECRET=your_client_secret_here
ATTIO_SCOPE=read:objects write:objects read:records write:records read:workspaces read:lists
REDIRECT_URI=http://localhost:3000/oauth/callback
```
2. Install dependencies: `npm install`
3. Run tests: `npm test`
4. Test OAuth flow and API endpoints using the provided API methods

### Why make this change?
To integrate Attio's functionality into the Frigg Framework, enabling users to interact with Attio's API for managing customer data, workspaces, and records. The core dependency updates ensure consistent functionality and feature support across modules.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-asana@2.0.0-canary.25.13cc249.0
  npm install @friggframework/api-module-attio@2.0.0-canary.25.13cc249.0
  npm install @friggframework/api-module-frontify@2.0.0-canary.25.13cc249.0
  npm install @friggframework/api-module-hubspot@2.0.0-canary.25.13cc249.0
  # or 
  yarn add @friggframework/api-module-asana@2.0.0-canary.25.13cc249.0
  yarn add @friggframework/api-module-attio@2.0.0-canary.25.13cc249.0
  yarn add @friggframework/api-module-frontify@2.0.0-canary.25.13cc249.0
  yarn add @friggframework/api-module-hubspot@2.0.0-canary.25.13cc249.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-asana@2.0.0-next.1`
`@friggframework/api-module-attio@1.0.1-next.0`
`@friggframework/api-module-frontify@2.0.0-next.1`
`@friggframework/api-module-hubspot@2.0.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 💥 Breaking Change
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Caught the lerna change. Seeing if this does a `next` release [#24](https://github.com/friggframework/api-module-library/pull/24) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-frontify`, `@friggframework/api-module-hubspot`
    - Bumped to core-next to resolve use-source-map issue [#25](https://github.com/friggframework/api-module-library/pull/25) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 1
  
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
