### PR TITLE
feat: changes to integrate asana with Frontify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10582,6 +10582,14 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -12159,6 +12167,28 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -12478,10 +12508,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "license": "MIT",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -12489,6 +12518,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -18748,6 +18788,24 @@
         "node": ">= 10.13"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -23300,6 +23358,14 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/packages/v1-ready/asana/api.js
+++ b/packages/v1-ready/asana/api.js
@@ -1,4 +1,5 @@
 const {OAuth2Requester, get} = require('@friggframework/core');
+const FormData = require('form-data');
 
 // core objects
 // - https://developers.asana.com/reference/projects
@@ -37,6 +38,9 @@ class Api extends OAuth2Requester {
             // Workspaces
             workspaces: '/workspaces',
             workspaceById: (workspaceId) => `/workspaces/${workspaceId}`,
+
+            // Attachments
+            attachments: '/attachments',
         };
 
         this.authorizationUri = encodeURI(
@@ -235,6 +239,63 @@ class Api extends OAuth2Requester {
     async getTaskById(id) {
         const options = {
             url: this.baseUrl + this.URLs.taskById(id),
+        };
+        return this._get(options);
+    }
+
+    async attachToTask(taskId, resourceURL) {
+        try {
+        
+            const fileName = resourceURL.split('/').pop();
+        
+            const formData = new FormData();
+            formData.append('parent', taskId);
+            formData.append('url', resourceURL);
+            formData.append('name', fileName);
+            formData.append('connect_to_app', 'true');
+            formData.append('resource_subtype', 'external');
+    
+            const options = {
+                method: 'POST',
+                url: this.baseUrl + this.URLs.attachments,
+                body: formData,
+                headers: {
+                    'Authorization': `Bearer ${this.access_token}`
+                }
+            };
+    
+            let response = await super._post(options, false);
+            
+            if (!response?.data) {
+                throw new Error('Failed to attach file to task: No response data received');
+            }
+
+            response = {
+                ...response.data,
+                resource_name: response.data.name,
+                resource_url: resourceURL,
+            };
+            
+            return response;
+          } catch (err) {
+            console.log(err);
+            throw err;
+          }
+    }
+
+    async listAttachments(taskId) {
+        const options = {
+            url: this.baseUrl + this.URLs.attachments,
+            query: {
+                parent: taskId,
+            },
+        };
+        return this._get(options);
+    }
+
+    async getAttachmentById(id) {
+        const options = {
+            url: `${this.baseUrl}${this.URLs.attachments}/${id}`,
         };
         return this._get(options);
     }

--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -247,6 +247,25 @@ class Api extends OAuth2Requester {
         return response.data;
     }
 
+    async listBrandAssets({ brandId, limit = 10, searchTerm = 'off' }) {
+        const query = `query BrandLevelSearch {
+            brand(id: "${brandId}") {
+                id
+                name
+                search(page: 1, limit: ${limit}, query: {term: "${searchTerm}"}) {
+                    total
+                    edges {
+                        title
+                    }
+                }
+            }
+        }`;
+
+        const response = await this._post(this.buildRequestOptions(query));
+        this.assertResponse(response);
+        return response.data.brand;
+    }
+
     async listProjects(query) {
         const ql = `query Projects {
                       brand(id: "${query.brandId}") {


### PR DESCRIPTION
### TL;DR
Added support for Asana attachments and Frontify brand asset search functionality.

### What changed?
- Added new Asana API endpoints for managing attachments:
  - `attachToTask`: Attach external resources to tasks
  - `listAttachments`: Get all attachments for a task
  - `getAttachmentById`: Retrieve specific attachment details
- Added Frontify `listBrandAssets` method to search for assets within a brand
- Added required dependencies: form-data and node-fetch

### How to test?
1. Test Asana attachment functionality:
```javascript
const api = new AsanaApi();
// Attach a file to a task
const attachment = await api.attachToTask('taskId', 'https://example.com/file.pdf');
// List attachments
const attachments = await api.listAttachments('taskId');
// Get specific attachment
const details = await api.getAttachmentById('attachmentId');
```

2. Test Frontify brand asset search:
```javascript
const api = new FrontifyApi();
const assets = await api.listBrandAssets({
    brandId: 'your-brand-id',
    limit: 10,
    searchTerm: 'search-query'
});
```

### Why make this change?
To enhance integration capabilities by supporting file attachments in Asana tasks and enabling brand asset search functionality in Frontify, providing more comprehensive API coverage for both platforms.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-asana@1.2.0-canary.26.cd6bf24.0
  npm install @friggframework/api-module-frontify@1.4.0-canary.26.cd6bf24.0
  # or 
  yarn add @friggframework/api-module-asana@1.2.0-canary.26.cd6bf24.0
  yarn add @friggframework/api-module-frontify@1.4.0-canary.26.cd6bf24.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-asana@2.0.0-next.2`
`@friggframework/api-module-frontify@2.0.0-next.2`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-asana`, `@friggframework/api-module-frontify`
    - feat: changes to integrate asana with Frontify [#26](https://github.com/friggframework/api-module-library/pull/26) ([@d-klotz](https://github.com/d-klotz) [@seanspeaks](https://github.com/seanspeaks))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Bumped to core-next to resolve use-source-map issue [#25](https://github.com/friggframework/api-module-library/pull/25) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
