### PR TITLE
Updated the attachment method to allow for file uploads

### DIFF
--- a/packages/v1-ready/asana/api.js
+++ b/packages/v1-ready/asana/api.js
@@ -243,19 +243,30 @@ class Api extends OAuth2Requester {
         return this._get(options);
     }
 
-    async attachToTask(taskId, resourceURL) {
+    async attachToTask(taskId, resource, options = {}) {
         try {
-        
-            const fileName = resourceURL.split('/').pop();
-        
             const formData = new FormData();
             formData.append('parent', taskId);
-            formData.append('url', resourceURL);
-            formData.append('name', fileName);
-            formData.append('connect_to_app', 'true');
-            formData.append('resource_subtype', 'external');
-    
-            const options = {
+
+            if (typeof resource === 'string') {
+                // Handle external URL attachment
+                const fileName = resource.split('/').pop();
+                formData.append('url', resource);
+                formData.append('name', fileName);
+                formData.append('connect_to_app', 'true');
+                formData.append('resource_subtype', 'external');
+            } else if (Buffer.isBuffer(resource) || resource instanceof Uint8Array) {
+                // Handle file upload from buffer
+                const fileName = options.fileName || 'attachment';
+                formData.append('file', resource, {
+                    filename: fileName,
+                    contentType: options.contentType || 'application/octet-stream'
+                });
+            } else {
+                throw new Error('Resource must be either a URL string or a Buffer/Uint8Array');
+            }
+
+            const requestOptions = {
                 method: 'POST',
                 url: this.baseUrl + this.URLs.attachments,
                 body: formData,
@@ -263,8 +274,8 @@ class Api extends OAuth2Requester {
                     'Authorization': `Bearer ${this.access_token}`
                 }
             };
-    
-            let response = await super._post(options, false);
+
+            let response = await super._post(requestOptions, false);
             
             if (!response?.data) {
                 throw new Error('Failed to attach file to task: No response data received');
@@ -273,14 +284,14 @@ class Api extends OAuth2Requester {
             response = {
                 ...response.data,
                 resource_name: response.data.name,
-                resource_url: resourceURL,
+                resource_url: typeof resource === 'string' ? resource : null,
             };
             
             return response;
-          } catch (err) {
+        } catch (err) {
             console.log(err);
             throw err;
-          }
+        }
     }
 
     async listAttachments(taskId) {


### PR DESCRIPTION
### TL;DR

Enhanced the `attachToTask` method in Asana API to support both URL attachments and file uploads from buffers.

### What changed?

- Modified the `attachToTask` method to accept either a URL string or a Buffer/Uint8Array as the resource parameter
- Added support for file uploads directly from memory buffers
- Introduced an optional `options` parameter that allows specifying filename and content type for buffer uploads
- Improved error handling and type checking for the resource parameter
- Fixed code formatting and indentation issues

### How to test?

1. Test URL attachment:
   ```javascript
   const result = await asanaApi.attachToTask('123456', 'https://example.com/file.pdf');
   ```

2. Test buffer upload:
   ```javascript
   const fileBuffer = Buffer.from('file content');
   const result = await asanaApi.attachToTask('123456', fileBuffer, {
     fileName: 'document.pdf',
     contentType: 'application/pdf'
   });
   ```

3. Verify that both methods correctly attach files to Asana tasks

### Why make this change?

This enhancement provides more flexibility when attaching files to Asana tasks. Previously, the method only supported attaching external URLs, but now it can also handle direct file uploads from memory buffers, which is useful for programmatically generated files or when processing files without saving them to disk first.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-asana@1.1.6-canary.28.ae47af4.0
  # or 
  yarn add @friggframework/api-module-asana@1.1.6-canary.28.ae47af4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-asana@2.0.0-next.3`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-asana`
    - Updated the attachment method to allow for file uploads [#28](https://github.com/friggframework/api-module-library/pull/28) ([@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Update with new searches in Library and Workspaces (Projects) [#27](https://github.com/friggframework/api-module-library/pull/27) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 1
  
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
