### PR TITLE
Add the methods back in

### DIFF
--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -617,14 +617,110 @@ class Api extends OAuth2Requester {
     }
 
     /**
-     * Lists assets in a subfolder
+     * Lists folders in a project with optional recursive nesting
      * @param {Object} query - Query parameters
-     * @param {string} query.subFolderId - ID of the subfolder
-     * @param {number} [query.page=1] - Page number
-     * @param {number} [query.limit=25] - Items per page
-     * @returns {Promise<Object>} Paginated list of assets
+     * @param {string} query.projectId - ID of the project
+     * @param {number} [query.page=1] - Page number for pagination
+     * @param {number} [query.limit=25] - Number of items per page
+     * @param {number} [query.nested=0] - Depth of nested folders to retrieve (max 10)
+     * @param {number} [query.recursive=0] - Alias for nested
+     * @returns {Promise<Object>} Paginated list of folders with nested structure if requested
      */
-    async listSubFolderAssets(query) {
+    async listProjectFolders(query) {
+        const depth = Math.min(query?.nested || query?.recursive || 0, 10);
+        const ql = `query ProjectFolders {
+                      workspaceProject(id: "${query.projectId}") {
+                        browse {
+                          folders(${this._paginationParamsQuery(query)}) {
+                            items {
+                              id
+                              name
+                              __typename
+                              ${this._nestedFoldersQuery(depth)}
+                            }
+                            ${this._paginationPropsQuery()}
+                          }
+                        }
+                      }
+                    }`;
+
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.workspaceProject.browse.folders;
+
+        return {
+            items,
+            total,
+            page,
+            hasNextPage
+        };
+    }
+
+    /**
+     * Lists folders in a library with optional recursive nesting
+     * @param {Object} query - Query parameters
+     * @param {string} query.libraryId - ID of the library
+     * @param {number} [query.page=1] - Page number for pagination
+     * @param {number} [query.limit=25] - Number of items per page
+     * @param {number} [query.nested=0] - Depth of nested folders to retrieve (max 10)
+     * @param {number} [query.recursive=0] - Alias for nested
+     * @returns {Promise<Object>} Paginated list of folders with nested structure if requested
+     */
+    async listLibraryFolders(query) {
+        const depth = Math.min(query?.nested || query?.recursive || 0, 10);
+        const ql = `query LibraryFolders {
+                      library(id: "${query.libraryId}") {
+                        browse {
+                          folders(${this._paginationParamsQuery(query)}) {
+                            items {
+                              id
+                              name
+                              createdAt
+                              modifiedAt
+                              __typename
+                              ${this._nestedFoldersQuery(depth)}
+                            }
+                            ${this._paginationPropsQuery()}
+                          }
+                        }
+                      }
+                    }`;
+
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.library.browse.folders;
+
+        return {
+            items,
+            total,
+            page,
+            hasNextPage
+        };
+    }
+
+    /**
+     * Lists subfolders within a folder with optional recursive nesting
+     * @param {Object} query - Query parameters
+     * @param {string} query.subFolderId - ID of the parent folder
+     * @param {number} [query.page=1] - Page number for pagination
+     * @param {number} [query.limit=25] - Number of items per page
+     * @param {number} [query.nested=0] - Depth of nested folders to retrieve (max 10)
+     * @param {number} [query.recursive=0] - Alias for nested
+     * @returns {Promise<Object>} Paginated list of subfolders with nested structure if requested
+     */
+    async listSubFolderFolders(query) {
         const depth = Math.min(query?.nested || query?.recursive || 0, 10);
         const ql = `query FolderById {
                       node(id: "${query.subFolderId}") {


### PR DESCRIPTION
### TL;DR

Added new folder listing APIs for Frontify projects and libraries with recursive nesting support.

### What changed?

- Added `listProjectFolders` method to retrieve folders from a project
- Added `listLibraryFolders` method to retrieve folders from a library
- Renamed `listSubFolderAssets` to `listSubFolderFolders` to better reflect its purpose
- Added support for recursive folder nesting with depth control (max 10 levels)
- Improved documentation with clearer parameter descriptions

### How to test?

Test the new APIs with:

```javascript
// List project folders with 2 levels of nesting
api.listProjectFolders({
  projectId: "your-project-id",
  nested: 2
});

// List library folders
api.listLibraryFolders({
  libraryId: "your-library-id"
});

// List subfolders with pagination
api.listSubFolderFolders({
  subFolderId: "your-folder-id",
  page: 1,
  limit: 50
});
```

### Why make this change?

These new methods provide more granular control over folder navigation in Frontify projects and libraries. The recursive nesting capability allows for retrieving complex folder structures in a single API call, improving efficiency when working with deeply nested content.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@1.3.1-canary.30.ef02adb.0
  # or 
  yarn add @friggframework/api-module-frontify@1.3.1-canary.30.ef02adb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-frontify@2.0.0-next.5`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-frontify`
    - Add the methods back in [#30](https://github.com/friggframework/api-module-library/pull/30) ([@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Added recursive folder retrieval for easier tree creation. Also, why not JSDocs. [#29](https://github.com/friggframework/api-module-library/pull/29) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 1
  
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
