### PR TITLE
Did things, third time trying to type this commit message

### DIFF
--- a/packages/v1-ready/asana/api.js
+++ b/packages/v1-ready/asana/api.js
@@ -63,6 +63,24 @@ class Api extends OAuth2Requester {
         return super.getTokenFromCode(code);
     }
 
+
+    async setTokens(params) {
+        this.access_token = get(params, 'access_token');
+        // this.refresh_token = get(params, 'refresh_token', null); // Removing because it sets to `null` but the request
+        // just doesn't return a refresh_token... long lived.
+        const accessExpiresIn = get(params, 'expires_in', null);
+        const refreshExpiresIn = get(
+            params,
+            'x_refresh_token_expires_in',
+            null
+        );
+
+        this.accessTokenExpire = new Date(Date.now() + accessExpiresIn * 1000);
+        this.refreshTokenExpire = new Date(Date.now() + refreshExpiresIn * 1000);
+
+        await this.notify(this.DLGT_TOKEN_UPDATE);
+    }
+
     addJsonHeaders(options) {
         const jsonHeaders = {
             'Content-Type': 'application/json',

--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -1079,13 +1079,16 @@ class Api extends OAuth2Requester {
     /**
      * Generates a nested folders query structure for GraphQL
      * @private
-     * @param {number} [depth=0] - Depth of nesting (max 10)
+     * @param {number} [depth=0] - Depth of nesting (max 5 recommended)
      * @returns {string} GraphQL query fragment for nested folders
      */
     _nestedFoldersQuery(depth = 0) {
-        const maxDepth = 10;
+        // Frontify has a max query depth of 20
+        // Given the base query structure, we should limit folder nesting to 5 levels
+        // to stay well within the limit while accounting for other fields
+        const maxDepth = 5;
         if (depth <= 0) return '';
-        const safeDepth = depth > maxDepth ? maxDepth : depth;
+        const safeDepth = Math.min(depth, maxDepth);
         
         return `
           folders {
@@ -1097,7 +1100,9 @@ class Api extends OAuth2Requester {
               __typename
               ${this._nestedFoldersQuery(safeDepth - 1)}
             }
-            ${this._paginationPropsQuery()}
+            total
+            page
+            hasNextPage
           }
         `;
     }


### PR DESCRIPTION
### TL;DR

Added token handling for Asana API and optimized Frontify's nested folder query structure.

### What changed?

- **Asana API**: Implemented a `setTokens` method to properly handle access tokens, expiration times, and token updates.
- **Frontify API**: Reduced the maximum folder nesting depth from 10 to 5 to prevent hitting GraphQL query depth limits, and simplified the pagination properties in nested folder queries.

### How to test?

1. **Asana**: Test OAuth flow to verify tokens are properly set and expiration times are calculated correctly.
2. **Frontify**: Test folder queries with deep nesting to ensure they work without hitting GraphQL depth limits.

### Why make this change?

- **Asana**: The implementation was missing proper token handling, which is necessary for maintaining authentication state.
- **Frontify**: The previous implementation risked hitting GraphQL query depth limits (max 20) when querying deeply nested folders. Reducing the max depth to 5 ensures we stay within limits while accounting for other fields in the query structure.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-asana@1.1.6-canary.32.a7101da.0
  npm install @friggframework/api-module-frontify@1.3.1-canary.32.a7101da.0
  # or 
  yarn add @friggframework/api-module-asana@1.1.6-canary.32.a7101da.0
  yarn add @friggframework/api-module-frontify@1.3.1-canary.32.a7101da.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-asana@2.0.0-next.4`
`@friggframework/api-module-frontify@2.0.0-next.7`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-asana`, `@friggframework/api-module-frontify`
    - Did things, third time trying to type this commit message [#32](https://github.com/friggframework/api-module-library/pull/32) ([@seanspeaks](https://github.com/seanspeaks))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - node:form-data doesn't exist. Thanks Cursor/AI and my like of node knowledge. [#31](https://github.com/friggframework/api-module-library/pull/31) ([@seanspeaks](https://github.com/seanspeaks))
  
  #### Authors: 1
  
  - Sean Matthews ([@seanspeaks](https://github.com/seanspeaks))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
