### PR TITLE
chore: update dependencies to latest canary versions for Frigg framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21696,11 +21696,11 @@
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "@friggframework/core": "^2.0.0-next.16"
+        "@friggframework/core": "^2.0.0--canary.395.65f5f64.0"
       },
       "devDependencies": {
-        "@friggframework/devtools": "^1.1.2",
-        "@friggframework/test": "^1.1.2",
+        "@friggframework/devtools": "^2.0.0--canary.395.65f5f64.0",
+        "@friggframework/test": "^2.0.0--canary.395.65f5f64.0",
         "dotenv": "^16.0.3",
         "eslint": "^8.22.0",
         "jest": "^28.1.3",
@@ -21730,6 +21730,57 @@
         "node-fetch": "^2.6.7",
         "serverless-http": "^2.7.0",
         "uuid": "^9.0.1"
+      }
+    },
+    "packages/v1-ready/asana/node_modules/@friggframework/devtools": {
+      "version": "2.0.0-next.27",
+      "resolved": "https://registry.npmjs.org/@friggframework/devtools/-/devtools-2.0.0-next.27.tgz",
+      "integrity": "sha512-z7YdUSDYy2Bb5NFmAZQNTdNFcrmhMB6cgUgU6Gai7iX6vni1/54IB3QdTJPC9UVCREwK4rnPAQL3rcR1NrcPbw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/eslint-parser": "^7.18.9",
+        "@babel/parser": "^7.25.3",
+        "@babel/traverse": "^7.25.3",
+        "@friggframework/test": "2.0.0-next.27",
+        "@hapi/boom": "^10.0.1",
+        "@inquirer/prompts": "^5.3.8",
+        "axios": "^1.7.2",
+        "body-parser": "^1.20.2",
+        "commander": "^12.1.0",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
+        "eslint": "^8.22.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-json": "^3.1.0",
+        "eslint-plugin-markdown": "^3.0.0",
+        "eslint-plugin-no-only-tests": "^3.0.0",
+        "eslint-plugin-yaml": "^0.5.0",
+        "express": "^4.19.2",
+        "express-async-handler": "^1.2.0",
+        "fs-extra": "^11.2.0",
+        "lodash": "4.17.21",
+        "serverless-http": "^2.7.0"
+      },
+      "bin": {
+        "frigg": "frigg-cli/index.js"
+      }
+    },
+    "packages/v1-ready/asana/node_modules/@friggframework/test": {
+      "version": "2.0.0-next.27",
+      "resolved": "https://registry.npmjs.org/@friggframework/test/-/test-2.0.0-next.27.tgz",
+      "integrity": "sha512-mXKu3EevnHIwpzM8nURU0MY0qJyn+BaneEp92CffPOnVWQ8mDckgHHW1kCJwv8AreoskQ3fDKIDeJfJqGYKY6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/eslint-parser": "^7.18.9",
+        "eslint": "^8.22.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-json": "^3.1.0",
+        "eslint-plugin-markdown": "^3.0.0",
+        "eslint-plugin-no-only-tests": "^3.0.0",
+        "eslint-plugin-yaml": "^0.5.0",
+        "jest-runner-groups": "^2.2.0",
+        "mongodb-memory-server": "^8.9.0",
+        "open": "^8.4.2"
       }
     },
     "packages/v1-ready/asana/node_modules/dotenv": {
@@ -24009,7 +24060,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@friggframework/core": "^2.0.0-next.16"
+        "@friggframework/core": "^2.0.0--canary.395.65f5f64.0"
       },
       "devDependencies": {
         "dotenv": "^16.3.1",
@@ -24020,9 +24071,9 @@
       }
     },
     "packages/v1-ready/frontify/node_modules/@friggframework/core": {
-      "version": "2.0.0-next.23",
-      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.23.tgz",
-      "integrity": "sha512-TtYVAB9gJ7voT7t69XqEEPeTSZIeiDphLuOFuAQHw4359bY63uYq+PX3QWxEX4EmTQeUTRL+EJ2TuABu4Ic9wg==",
+      "version": "2.0.0--canary.395.65f5f64.0",
+      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0--canary.395.65f5f64.0.tgz",
+      "integrity": "sha512-IlKs99b9eF7qZ1c7atUZ49nZl2yxW+To9aVLXqxfIMTtbnugr50oRbTcFzrxaTPu6ImH3wRrlZs/k3QCKDSVTg==",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "aws-sdk": "^2.1200.0",

--- a/packages/v1-ready/asana/package.json
+++ b/packages/v1-ready/asana/package.json
@@ -11,8 +11,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@friggframework/devtools": "^1.1.2",
-    "@friggframework/test": "^1.1.2",
+    "@friggframework/devtools": "^2.0.0--canary.395.65f5f64.0",
+    "@friggframework/test": "^2.0.0--canary.395.65f5f64.0",
     "dotenv": "^16.0.3",
     "eslint": "^8.22.0",
     "jest": "^28.1.3",
@@ -20,7 +20,7 @@
     "prettier": "^2.7.1"
   },
   "dependencies": {
-    "@friggframework/core": "^2.0.0-next.16"
+    "@friggframework/core": "^2.0.0--canary.395.65f5f64.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/v1-ready/frontify/package.json
+++ b/packages/v1-ready/frontify/package.json
@@ -18,7 +18,7 @@
     "sinon": "^16.0.0"
   },
   "dependencies": {
-    "@friggframework/core": "^2.0.0-next.16"
+    "@friggframework/core": "^2.0.0--canary.395.65f5f64.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-asana@1.2.0-canary.44.a3de0d1.0
  npm install @friggframework/api-module-frontify@1.4.0-canary.44.a3de0d1.0
  # or 
  yarn add @friggframework/api-module-asana@1.2.0-canary.44.a3de0d1.0
  yarn add @friggframework/api-module-frontify@1.4.0-canary.44.a3de0d1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
