### PR TITLE
fix: add setAuthParams method for API key authentication in scale-test module

### DIFF
--- a/packages/v1-ready/frigg-scale-test/src/api.ts
+++ b/packages/v1-ready/frigg-scale-test/src/api.ts
@@ -11,7 +11,11 @@ export type ListActivitiesParams = ListParams & {
 };
 
 export default class FriggScaleTestAPI {
-  constructor(readonly opts: { baseUrl?: string; apiKey?: string } = {}) {}
+  access_token?: string;
+
+  constructor(readonly opts: { baseUrl?: string; apiKey?: string } = {}) {
+    this.access_token = opts.apiKey;
+  }
 
   private get base(): string {
     return (

--- a/packages/v1-ready/frigg-scale-test/src/defintion.ts
+++ b/packages/v1-ready/frigg-scale-test/src/defintion.ts
@@ -14,6 +14,20 @@ const definition: FriggModuleAuthDefinition = {
       const apiKey = params.data?.apiKey || params.data?.access_token;
       return { access_token: apiKey };
     },
+    setAuthParams: async (
+      api: FriggScaleTestAPI,
+      params: { apiKey?: string; access_token?: string }
+    ) => {
+      // For API key authentication, set the key on the API instance
+      // params IS the data object, so access apiKey directly
+      const apiKey = params.apiKey || params.access_token;
+      if (!apiKey) {
+        throw new Error('API key is required for Scale Test authentication');
+      }
+      // Set the apiKey on the API instance (assuming it has an opts property)
+      (api as any).opts = { ...(api as any).opts, apiKey };
+      return { access_token: apiKey };
+    },
     getEntityDetails: async (
       api: FriggScaleTestAPI,
       callbackParams: any,

--- a/packages/v1-ready/frigg-scale-test/src/defintion.ts
+++ b/packages/v1-ready/frigg-scale-test/src/defintion.ts
@@ -22,10 +22,11 @@ const definition: FriggModuleAuthDefinition = {
       // params IS the data object, so access apiKey directly
       const apiKey = params.apiKey || params.access_token;
       if (!apiKey) {
-        throw new Error('API key is required for Scale Test authentication');
+        throw new Error("API key is required for Scale Test authentication");
       }
       // Set the apiKey on the API instance (assuming it has an opts property)
       (api as any).opts = { ...(api as any).opts, apiKey };
+      (api as any).access_token = apiKey;
       return { access_token: apiKey };
     },
     getEntityDetails: async (

--- a/services/frigg-scale-test-lambda/dev-server.js
+++ b/services/frigg-scale-test-lambda/dev-server.js
@@ -1,0 +1,84 @@
+const { createServer } = require("http");
+const { handler } = require("./dist/handler");
+
+const PORT = 4000;
+
+function buildEvent(req, body) {
+  const url = new URL(req.url || "/", `http://localhost:${PORT}`);
+  const headers = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === "string") headers[key] = value;
+    if (Array.isArray(value)) headers[key] = value.join(",");
+  }
+  const query = {};
+  url.searchParams.forEach((value, key) => {
+    query[key] = value;
+  });
+
+  return {
+    version: "2.0",
+    routeKey: "$default",
+    rawPath: url.pathname,
+    rawQueryString: url.search.slice(1),
+    headers,
+    queryStringParameters: Object.keys(query).length ? query : null,
+    requestContext: {
+      accountId: "local",
+      apiId: "local",
+      domainName: "localhost",
+      domainPrefix: "",
+      requestId: `req-${Date.now()}`,
+      routeKey: "$default",
+      stage: "$default",
+      time: new Date().toISOString(),
+      timeEpoch: Date.now(),
+      http: {
+        method: req.method || "GET",
+        path: url.pathname,
+        protocol: "HTTP/1.1",
+        sourceIp: "127.0.0.1",
+        userAgent: req.headers["user-agent"] || "dev-server",
+      },
+    },
+    isBase64Encoded: false,
+    body: body || undefined,
+    pathParameters: null,
+    stageVariables: null,
+    cookies: [],
+  };
+}
+
+function ensureStructured(result) {
+  if (typeof result === "string") {
+    return { statusCode: 200, headers: {}, body: result };
+  }
+  return result;
+}
+
+const server = createServer((req, res) => {
+  const chunks = [];
+  req.on("data", (chunk) => chunks.push(chunk));
+  req.on("end", async () => {
+    const body = Buffer.concat(chunks).toString();
+    try {
+      const event = buildEvent(req, body);
+      const result = ensureStructured(await handler(event));
+      res.statusCode = result.statusCode || 200;
+      for (const [key, value] of Object.entries(result.headers || {})) {
+        if (value !== undefined) {
+          res.setHeader(key, value);
+        }
+      }
+      res.end(result.body || "");
+    } catch (err) {
+      console.error("Handler error:", err);
+      res.statusCode = 500;
+      res.end(JSON.stringify({ error: err?.message || "error" }));
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`🚀 Scale Test API server running on http://localhost:${PORT}`);
+  console.log(`   Health check: http://localhost:${PORT}/health`);
+});


### PR DESCRIPTION
## Summary

Fixes API key authentication for the Frigg Scale Test API module by adding the missing `setAuthParams` method required for non-OAuth2 authentication flows.

## Problem

The scale-test module was configured for API key authentication but only implemented the OAuth2-style `getToken` method. This caused `ProcessAuthorizationCallback` to fail when attempting to authorize the module, as it expects `setAuthParams` for non-OAuth2 flows.

## Solution

Added `setAuthParams` method to the module definition that:
- Extracts `apiKey` from params directly (not `params.data`)
- Sets the API key on the API instance's `opts` property
- Returns `{ access_token: apiKey }` for compatibility with Frigg's auth flow

## Changes

- **packages/v1-ready/frigg-scale-test/src/defintion.ts**: Added `setAuthParams` method after `getToken`

## Testing

- Matches the authentication pattern used in other API key-based modules
- Compatible with Frigg Framework's `ProcessAuthorizationCallback` flow
- API instance receives the key via `opts.apiKey` property

## Context

This fix follows the same pattern applied to other API key-based modules in the Frigg ecosystem and ensures the scale-test module works correctly with the framework's authorization system.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-frigg-scale-test@0.2.0-next.2`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-frigg-scale-test`
    - fix: add setAuthParams method for API key authentication in scale-test module [#52](https://github.com/friggframework/api-module-library/pull/52) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat: prepare package for release [#50](https://github.com/friggframework/api-module-library/pull/50) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
