### PR TITLE
refactor: attio api-module

### DIFF
--- a/packages/v1-ready/attio/api.js
+++ b/packages/v1-ready/attio/api.js
@@ -8,19 +8,20 @@ class Api extends OAuth2Requester {
         this.URLs = {
             authorization: '/oauth/authorize',
             access_token: '/oauth/token',
-            userDetails: '/auth/me',
+            userDetails: '/self',
             objects: '/objects',
             objectById: (objectId) => `/objects/${objectId}`,
             records: (objectId) => `/objects/${objectId}/records`,
             recordById: (objectId, recordId) => `/objects/${objectId}/records/${recordId}`,
-            search: (objectId) => `/objects/${objectId}/records/search`,
+            query: (objectId) => `/objects/${objectId}/records/query`,
             attributes: (objectId) => `/objects/${objectId}/attributes`,
             attributeById: (objectId, attributeId) => `/objects/${objectId}/attributes/${attributeId}`,
-            workspaces: '/workspaces',
-            workspaceById: (workspaceId) => `/workspaces/${workspaceId}`,
+            // Note: /workspaces and /workspaces/{id} endpoints don't exist in Attio API
+            // Workspaces are referenced via workspace_id in other objects
+            // Use /workspace_members endpoint instead if needed
             lists: '/lists',
             listById: (listId) => `/lists/${listId}`,
-            listRecords: (listId) => `/lists/${listId}/records`,
+            listEntries: (listId) => `/lists/${listId}/entries`,
         };
     }
 
@@ -46,11 +47,24 @@ class Api extends OAuth2Requester {
     }
 
     async listRecords(objectId, params = {}) {
-        const options = {
-            url: this.baseUrl + this.URLs.records(objectId),
-            params,
-        };
-        return this.get(options);
+        // Attio uses POST /v2/objects/{object}/records/query, not GET /records
+        // Convert params to query body format
+        const query = {};
+
+        if (params.limit) {
+            query.limit = params.limit;
+        }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
+        if (params.sorts) {
+            query.sorts = params.sorts;
+        }
+        if (params.filter) {
+            query.filter = params.filter;
+        }
+
+        return this.queryRecords(objectId, query);
     }
 
     async getRecord(objectId, recordId) {
@@ -89,9 +103,9 @@ class Api extends OAuth2Requester {
         return this.delete(options);
     }
 
-    async searchRecords(objectId, query) {
+    async queryRecords(objectId, query) {
         const options = {
-            url: this.baseUrl + this.URLs.search(objectId),
+            url: this.baseUrl + this.URLs.query(objectId),
             headers: {
                 'Content-Type': 'application/json',
             },
@@ -114,19 +128,10 @@ class Api extends OAuth2Requester {
         return this.get(options);
     }
 
-    async listWorkspaces() {
-        const options = {
-            url: this.baseUrl + this.URLs.workspaces,
-        };
-        return this.get(options);
-    }
-
-    async getWorkspace(workspaceId) {
-        const options = {
-            url: this.baseUrl + this.URLs.workspaceById(workspaceId),
-        };
-        return this.get(options);
-    }
+    // Note: listWorkspaces() and getWorkspace() methods removed
+    // These endpoints don't exist in the Attio API
+    // Workspaces are referenced via workspace_id in other API responses
+    // Use workspace_members endpoint if you need to work with workspace data
 
     async listLists() {
         const options = {
@@ -142,12 +147,101 @@ class Api extends OAuth2Requester {
         return this.get(options);
     }
 
-    async getListRecords(listId, params = {}) {
+    async getListEntries(listId, params = {}) {
         const options = {
-            url: this.baseUrl + this.URLs.listRecords(listId),
+            url: this.baseUrl + this.URLs.listEntries(listId),
             params,
         };
         return this.get(options);
+    }
+
+    // ============================================================================
+    // Notes API
+    // ============================================================================
+
+    async listNotes(params = {}) {
+        const options = {
+            url: this.baseUrl + '/notes',
+            params,
+        };
+        return this.get(options);
+    }
+
+    async getNote(noteId) {
+        const options = {
+            url: this.baseUrl + `/notes/${noteId}`,
+        };
+        return this.get(options);
+    }
+
+    async createNote(data) {
+        const options = {
+            url: this.baseUrl + '/notes',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: { data },
+        };
+        return this.post(options);
+    }
+
+    async deleteNote(noteId) {
+        const options = {
+            url: this.baseUrl + `/notes/${noteId}`,
+        };
+        return this.delete(options);
+    }
+
+    // ============================================================================
+    // Webhooks API
+    // ============================================================================
+
+    async listWebhooks(params = {}) {
+        const options = {
+            url: this.baseUrl + '/webhooks',
+            params,
+        };
+        return this.get(options);
+    }
+
+    async getWebhook(webhookId) {
+        const options = {
+            url: this.baseUrl + `/webhooks/${webhookId}`,
+        };
+        return this.get(options);
+    }
+
+    async createWebhook(data) {
+        const options = {
+            url: this.baseUrl + '/webhooks',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: { data },
+        };
+        return this.post(options);
+    }
+
+    async deleteWebhook(webhookId) {
+        const options = {
+            url: this.baseUrl + `/webhooks/${webhookId}`,
+        };
+        return this.delete(options);
+    }
+
+    // ============================================================================
+    // Search API
+    // ============================================================================
+
+    async searchRecords(searchParams) {
+        const options = {
+            url: this.baseUrl + '/objects/records/search',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: searchParams,
+        };
+        return this.post(options);
     }
 }
 

--- a/packages/v1-ready/attio/api.js
+++ b/packages/v1-ready/attio/api.js
@@ -16,9 +16,6 @@ class Api extends OAuth2Requester {
             query: (objectId) => `/objects/${objectId}/records/query`,
             attributes: (objectId) => `/objects/${objectId}/attributes`,
             attributeById: (objectId, attributeId) => `/objects/${objectId}/attributes/${attributeId}`,
-            // Note: /workspaces and /workspaces/{id} endpoints don't exist in Attio API
-            // Workspaces are referenced via workspace_id in other objects
-            // Use /workspace_members endpoint instead if needed
             lists: '/lists',
             listById: (listId) => `/lists/${listId}`,
             listEntries: (listId) => `/lists/${listId}/entries`,
@@ -47,8 +44,6 @@ class Api extends OAuth2Requester {
     }
 
     async listRecords(objectId, params = {}) {
-        // Attio uses POST /v2/objects/{object}/records/query, not GET /records
-        // Convert params to query body format
         const query = {};
 
         if (params.limit) {
@@ -128,11 +123,6 @@ class Api extends OAuth2Requester {
         return this.get(options);
     }
 
-    // Note: listWorkspaces() and getWorkspace() methods removed
-    // These endpoints don't exist in the Attio API
-    // Workspaces are referenced via workspace_id in other API responses
-    // Use workspace_members endpoint if you need to work with workspace data
-
     async listLists() {
         const options = {
             url: this.baseUrl + this.URLs.lists,
@@ -154,10 +144,6 @@ class Api extends OAuth2Requester {
         };
         return this.get(options);
     }
-
-    // ============================================================================
-    // Notes API
-    // ============================================================================
 
     async listNotes(params = {}) {
         const options = {
@@ -192,10 +178,6 @@ class Api extends OAuth2Requester {
         return this.delete(options);
     }
 
-    // ============================================================================
-    // Webhooks API
-    // ============================================================================
-
     async listWebhooks(params = {}) {
         const options = {
             url: this.baseUrl + '/webhooks',
@@ -228,10 +210,6 @@ class Api extends OAuth2Requester {
         };
         return this.delete(options);
     }
-
-    // ============================================================================
-    // Search API
-    // ============================================================================
 
     async searchRecords(searchParams) {
         const options = {

--- a/packages/v1-ready/attio/definition.js
+++ b/packages/v1-ready/attio/definition.js
@@ -14,10 +14,18 @@ const Definition = {
             return api.getTokenFromCode(code);
         },
         getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {
-            const userDetails = await api.getUserDetails();
+            const tokenInfo = await api.getUserDetails(); // Returns /v2/self response with workspace info
+
+            if (!tokenInfo || !tokenInfo.workspace_id) {
+                throw new Error(
+                    'Attio /v2/self failed to return valid workspace info. ' +
+                    'Response: ' + JSON.stringify(tokenInfo)
+                );
+            }
+
             return {
-                identifiers: {externalId: userDetails.id, user: userId},
-                details: {name: userDetails.email},
+                identifiers: {externalId: tokenInfo.workspace_id, user: userId},
+                details: {name: tokenInfo.workspace_name || tokenInfo.workspace_slug},
             }
         },
         apiPropertiesToPersist: {
@@ -27,9 +35,17 @@ const Definition = {
             entity: [],
         },
         getCredentialDetails: async (api, userId) => {
-            const userDetails = await api.getUserDetails();
+            const tokenInfo = await api.getUserDetails(); // Returns /v2/self response with workspace info
+
+            if (!tokenInfo || !tokenInfo.workspace_id) {
+                throw new Error(
+                    'Attio /v2/self failed to return valid workspace info. ' +
+                    'Response: ' + JSON.stringify(tokenInfo)
+                );
+            }
+
             return {
-                identifiers: {externalId: userDetails.id, user: userId},
+                identifiers: {externalId: tokenInfo.workspace_id, user: userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/attio/definition.js
+++ b/packages/v1-ready/attio/definition.js
@@ -10,7 +10,7 @@ const Definition = {
     modelName: 'Attio',
     requiredAuthMethods: {
         getToken: async (api, params) => {
-            const code = get(params.data, 'code');
+            const code = get(params, 'code');
             return api.getTokenFromCode(code);
         },
         getEntityDetails: async (api, callbackParams, tokenResponse, userId) => {


### PR DESCRIPTION
This pull request refactors the Attio API integration to align with the latest Attio API endpoints and data models. The main changes include updating endpoint URLs, removing unsupported workspace methods, revising record querying logic, and adding full support for Notes and Webhooks APIs. Additionally, entity and credential detail retrieval now reflect workspace-level information instead of user-level.

**API endpoint updates and removals:**

* Updated endpoint URLs in `api.js` to match the current Attio API, including changing `/auth/me` to `/self`, `/records/search` to `/records/query`, and `/lists/{id}/records` to `/lists/{id}/entries`. Removed workspace endpoints and related methods, as these are no longer supported. [[1]](diffhunk://#diff-d545ede19d971e67b942e63c6c0ec89d907e23e833966dfe7db36119b578866bL11-R24) [[2]](diffhunk://#diff-d545ede19d971e67b942e63c6c0ec89d907e23e833966dfe7db36119b578866bL117-R245)
* Refactored record querying: `listRecords` now uses a POST to `/objects/{object}/records/query` with a query body, replacing the previous GET request; the corresponding method was renamed from `searchRecords` to `queryRecords`. [[1]](diffhunk://#diff-d545ede19d971e67b942e63c6c0ec89d907e23e833966dfe7db36119b578866bL49-R67) [[2]](diffhunk://#diff-d545ede19d971e67b942e63c6c0ec89d907e23e833966dfe7db36119b578866bL92-R108)

**New API features:**

* Added full support for Notes and Webhooks APIs with methods for listing, retrieving, creating, and deleting notes and webhooks.
* Introduced a generic `searchRecords` method for POST-based searching on `/objects/records/search`.

**Entity and credential details logic:**

* Updated entity and credential detail retrieval in `definition.js` to use workspace-level information from `/self` instead of user-level info, with validation for workspace presence. [[1]](diffhunk://#diff-5ca3a0a791383f63135ea7f843739c612f510ac1edc8dc7d12c0c447a7c36f31L13-R28) [[2]](diffhunk://#diff-5ca3a0a791383f63135ea7f843739c612f510ac1edc8dc7d12c0c447a7c36f31L30-R48)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-attio@1.0.1-canary.54.b4bc72c.0
  # or 
  yarn add @friggframework/api-module-attio@1.0.1-canary.54.b4bc72c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-attio@1.1.0-next.0`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix: correct API name and enhance authorization requirements for scale-test module [#53](https://github.com/friggframework/api-module-library/pull/53) ([@d-klotz](https://github.com/d-klotz))
    - fix: add setAuthParams method for API key authentication in scale-test module [#52](https://github.com/friggframework/api-module-library/pull/52) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-attio`
    - refactor: attio api-module [#54](https://github.com/friggframework/api-module-library/pull/54) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
