### PR TITLE
fix: update @types/aws-lambda version and adjust optional flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6081,10 +6081,10 @@
       "license": "0BSD"
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.149",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.149.tgz",
-      "integrity": "sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==",
-      "optional": true
+      "version": "8.10.156",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.156.tgz",
+      "integrity": "sha512-LElQP+QliVWykC7OF8dNr04z++HJCMO2lF7k9HuKoSDARqhcjHq8MzbrRwujCSDeBHIlvaimbuY/tVZL36KXFQ==",
+      "devOptional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -24203,12 +24203,14 @@
       }
     },
     "packages/v1-ready/frigg-scale-test": {
+      "name": "@friggframework/api-module-frigg-scale-test",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@friggframework/core": "^1.0.0"
       },
       "devDependencies": {
+        "@types/aws-lambda": "^8.10.156",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.8.0",
         "jest": "^29.7.0",

--- a/packages/v1-ready/frigg-scale-test/package.json
+++ b/packages/v1-ready/frigg-scale-test/package.json
@@ -19,6 +19,7 @@
     "@friggframework/core": "^1.0.0"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.156",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.8.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
This pull request adds a new development dependency to the `frigg-scale-test` package to improve type support for AWS Lambda functions.

* Dependency updates:
  * Added `@types/aws-lambda` to `devDependencies` in `package.json` to provide TypeScript type definitions for AWS Lambda.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-frigg-scale-test@0.2.0-next.4`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-frigg-scale-test`
    - fix: update @types/aws-lambda version and adjust optional flag [#55](https://github.com/friggframework/api-module-library/pull/55) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - refactor: attio api-module [#54](https://github.com/friggframework/api-module-library/pull/54) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
