### PR TITLE
feat: Add webhook management functionality to Pipedrive and Zoho CRM API integrations

### DIFF
--- a/packages/v1-ready/attio/api.js
+++ b/packages/v1-ready/attio/api.js
@@ -224,7 +224,7 @@ class Api extends OAuth2Requester {
             },
             body: { data },
         };
-        return this.patch(options);
+        return this._patch(options);
     }
 
     async searchRecords(searchParams) {

--- a/packages/v1-ready/attio/api.js
+++ b/packages/v1-ready/attio/api.js
@@ -23,6 +23,7 @@ class Api extends OAuth2Requester {
             lists: '/lists',
             listById: (listId) => `/lists/${listId}`,
             listEntries: (listId) => `/lists/${listId}/entries`,
+            webhookById: (webhookId) => `/webhooks/${webhookId}`,
         };
     }
 
@@ -213,6 +214,17 @@ class Api extends OAuth2Requester {
             url: this.baseUrl + `/webhooks/${webhookId}`,
         };
         return this._delete(options);
+    }
+
+    async updateWebhook(webhookId, data) {
+        const options = {
+            url: this.baseUrl + this.URLs.webhookById(webhookId),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: { data },
+        };
+        return this.patch(options);
     }
 
     async searchRecords(searchParams) {

--- a/packages/v1-ready/pipedrive/src/api.ts
+++ b/packages/v1-ready/pipedrive/src/api.ts
@@ -11,6 +11,7 @@ import {
   PipedriveResponse,
   PipedriveUser,
   PipedriveTokenResponse,
+  CreateWebhookParams,
 } from "./types";
 
 export class Api extends OAuth2Requester {
@@ -26,6 +27,8 @@ export class Api extends OAuth2Requester {
     personById: (personId: string | number) => string;
     organizations: string;
     organizationById: (orgId: string | number) => string;
+    webhooks: string;
+    webhookById: (webhookId: string | number) => string;
   };
 
   constructor(params: OAuth2RequesterOptions) {
@@ -47,6 +50,8 @@ export class Api extends OAuth2Requester {
       personById: (personId: string | number) => `/v2/persons/${personId}`,
       organizations: "/v2/organizations",
       organizationById: (orgId: string | number) => `/v2/organizations/${orgId}`,
+      webhooks: "/v1/webhooks",
+      webhookById: (webhookId: string | number) => `/v1/webhooks/${webhookId}`,
     };
 
     this.authorizationUri = encodeURI(
@@ -250,5 +255,55 @@ export class Api extends OAuth2Requester {
       options.query = params;
     }
     return this._get(options);
+  }
+
+  // **************************   Webhooks   **********************************
+  /**
+   * List all webhooks for the company
+   * @returns Response with array of webhook configurations
+   */
+  async listWebhooks(): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.webhooks,
+    };
+    return this._get(options);
+  }
+
+  /**
+   * Create a new webhook subscription
+   * @param params - Webhook configuration
+   * @param params.subscription_url - Public HTTPS URL to receive webhooks
+   * @param params.event_action - Event action: added, updated, deleted, merged, *
+   * @param params.event_object - Event object: person, organization, deal, activity, product, *
+   * @param params.name - Human-readable name for the webhook
+   * @param params.user_id - Optional: User ID to authorize webhook with
+   * @param params.http_auth_user - Optional: HTTP basic auth username
+   * @param params.http_auth_password - Optional: HTTP basic auth password
+   * @param params.version - Optional: Webhook version (1.0 or 2.0, default: 2.0)
+   * @returns Response with created webhook data
+   */
+  async createWebhook(params: CreateWebhookParams): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.webhooks,
+      body: params,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+    return this._post(options);
+  }
+
+  /**
+   * Delete a webhook by ID
+   * @param webhookId - The ID of the webhook to delete
+   * @returns Response confirming deletion
+   */
+  async deleteWebhook(
+    webhookId: string | number
+  ): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.webhookById(webhookId),
+    };
+    return this._delete(options);
   }
 }

--- a/packages/v1-ready/pipedrive/src/api.ts
+++ b/packages/v1-ready/pipedrive/src/api.ts
@@ -4,8 +4,12 @@ import {
   ActivityParams,
   ListActivitiesParams,
   ListDealsParams,
+  CreateDealParams,
   ListPersonsParams,
   GetPersonParams,
+  SearchPersonsParams,
+  SearchParams,
+  CreateNoteParams,
   ListOrganizationsParams,
   GetOrganizationParams,
   PipedriveResponse,
@@ -25,10 +29,13 @@ export class Api extends OAuth2Requester {
     deals: string;
     persons: string;
     personById: (personId: string | number) => string;
+    personsSearch: string;
     organizations: string;
     organizationById: (orgId: string | number) => string;
+    notes: string;
     webhooks: string;
     webhookById: (webhookId: string | number) => string;
+    search: string;
   };
 
   constructor(params: OAuth2RequesterOptions) {
@@ -48,10 +55,13 @@ export class Api extends OAuth2Requester {
       deals: "/v2/deals",
       persons: "/v2/persons",
       personById: (personId: string | number) => `/v2/persons/${personId}`,
+      personsSearch: "/v2/persons/search",
       organizations: "/v2/organizations",
       organizationById: (orgId: string | number) => `/v2/organizations/${orgId}`,
+      notes: "/v1/notes",
       webhooks: "/v1/webhooks",
       webhookById: (webhookId: string | number) => `/v1/webhooks/${webhookId}`,
+      search: "/v1/search",
     };
 
     this.authorizationUri = encodeURI(
@@ -109,6 +119,29 @@ export class Api extends OAuth2Requester {
       options.query = params;
     }
     return this._get(options);
+  }
+
+  /**
+   * Create a new deal
+   * @param params - Deal data
+   * @param params.title - Deal title (required)
+   * @param params.value - Deal value
+   * @param params.currency - Currency code
+   * @param params.person_id - Associated person ID
+   * @param params.org_id - Associated organization ID
+   * @param params.pipeline_id - Pipeline ID
+   * @param params.stage_id - Stage ID
+   * @returns Response with created deal data
+   */
+  async createDeal(params: CreateDealParams): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.deals,
+      body: params,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+    return this._post(options);
   }
 
   // **************************   Activities   **********************************
@@ -218,6 +251,70 @@ export class Api extends OAuth2Requester {
       options.query = params;
     }
     return this._get(options);
+  }
+
+  /**
+   * Search for persons
+   * @param params - Search parameters
+   * @param params.term - The search term (minimum 2 characters, or 1 if using exact_match)
+   * @param params.fields - Comma-separated fields to search in
+   * @param params.exact_match - When enabled, only full exact matches are returned
+   * @param params.organization_id - Filter persons by organization ID
+   * @param params.include_fields - Optional fields to include (e.g., "person.picture")
+   * @param params.limit - Number of entries to return (default 100, max 500)
+   * @param params.cursor - Pagination cursor
+   * @returns Response with search results including items with result_score and person data
+   */
+  async searchPersons(params: SearchPersonsParams): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.personsSearch,
+      query: params,
+    };
+    return this._get(options);
+  }
+
+  /**
+   * Search across all items (persons, organizations, deals, etc.)
+   * @param params - Search parameters
+   * @param params.term - The search term (minimum 2 characters)
+   * @param params.item_types - Comma-separated item types to search (e.g., 'person,organization,deal')
+   * @param params.exact_match - When enabled, only full exact matches are returned
+   * @param params.fields - Comma-separated fields to search in
+   * @param params.limit - Number of entries to return (default 10, max 100)
+   * @param params.start - Pagination start
+   * @returns Response with search results across multiple item types
+   */
+  async search(params: SearchParams): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.search,
+      query: params,
+    };
+    return this._get(options);
+  }
+
+  // **************************   Notes   **********************************
+  /**
+   * Create a new note
+   * @param params - Note data
+   * @param params.content - The content of the note in HTML format (required)
+   * @param params.lead_id - The ID of the lead (UUID format)
+   * @param params.deal_id - The ID of the deal
+   * @param params.person_id - The ID of the person
+   * @param params.org_id - The ID of the organization
+   * @param params.project_id - The ID of the project
+   * @param params.user_id - The ID of the user (author)
+   * @param params.add_time - Creation date & time in UTC (Format: YYYY-MM-DD HH:MM:SS)
+   * @returns Response with created note data
+   */
+  async createNote(params: CreateNoteParams): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.notes,
+      body: params,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+    return this._post(options);
   }
 
   // **************************   Organizations   **********************************

--- a/packages/v1-ready/pipedrive/src/types.d.ts
+++ b/packages/v1-ready/pipedrive/src/types.d.ts
@@ -169,6 +169,55 @@ export interface GetPersonParams {
   custom_fields?: string;
 }
 
+export interface SearchPersonsParams {
+  term: string;
+  fields?: string;
+  exact_match?: boolean;
+  organization_id?: number;
+  include_fields?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface CreateDealParams {
+  title: string;
+  value?: number;
+  currency?: string;
+  person_id?: number;
+  org_id?: number;
+  pipeline_id?: number;
+  stage_id?: number;
+  status?: 'open' | 'won' | 'lost';
+  probability?: number;
+  expected_close_date?: string;
+  visible_to?: number;
+}
+
+export interface SearchParams {
+  term: string;
+  item_types?: string;
+  exact_match?: boolean;
+  fields?: string;
+  limit?: number;
+  start?: number;
+}
+
+export interface CreateNoteParams {
+  content: string;
+  lead_id?: string;
+  deal_id?: number;
+  person_id?: number;
+  org_id?: number;
+  project_id?: number;
+  user_id?: number;
+  add_time?: string;
+  pinned_to_lead_flag?: 0 | 1;
+  pinned_to_deal_flag?: 0 | 1;
+  pinned_to_organization_flag?: 0 | 1;
+  pinned_to_person_flag?: 0 | 1;
+  pinned_to_project_flag?: 0 | 1;
+}
+
 export interface ListOrganizationsParams {
   /** For pagination, cursor marker for next page */
   cursor?: string;
@@ -395,6 +444,29 @@ export interface Person {
   birthday?: string;
   job_title?: string;
   custom_fields?: Record<string, any>;
+}
+
+/**
+ * Search result item from persons search endpoint
+ */
+export interface SearchPersonItem {
+  result_score: number;
+  item: {
+    id: number;
+    type: string;
+    name: string;
+    phones?: string[];
+    emails?: string[];
+    visible_to?: number;
+    owner?: { id: number };
+    organization?: {
+      id: number;
+      name: string;
+      address: string | null;
+    };
+    custom_fields?: any[];
+    notes?: any[];
+  };
 }
 
 /**

--- a/packages/v1-ready/pipedrive/src/types.d.ts
+++ b/packages/v1-ready/pipedrive/src/types.d.ts
@@ -433,3 +433,32 @@ export interface Organization {
   lost_deals_count?: number;
   related_lost_deals_count?: number;
 }
+
+// ==================== Webhook Types ====================
+
+export interface CreateWebhookParams {
+  subscription_url: string;
+  event_action: "added" | "updated" | "deleted" | "merged" | "*";
+  event_object: "person" | "organization" | "deal" | "activity" | "product" | "pipeline" | "stage" | "user" | "*";
+  name: string;
+  user_id?: number;
+  http_auth_user?: string;
+  http_auth_password?: string;
+  version?: "1.0" | "2.0";
+}
+
+export interface WebhookData {
+  id: number;
+  company_id: number;
+  subscription_url: string;
+  event_action: string;
+  event_object: string;
+  name: string;
+  user_id: number;
+  http_auth_user?: string;
+  version: string;
+  add_time: string;
+  remove_time?: string;
+  active_flag: boolean;
+  last_delivery_time?: string;
+}

--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -14,6 +14,8 @@ import {
     AccountsResponse,
     AccountResponse,
     TokenResponse,
+    WebhookConfig,
+    WebhookResponse,
 } from './types';
 
 export class Api extends OAuth2Requester {
@@ -48,6 +50,8 @@ export class Api extends OAuth2Requester {
             accounts: '/Accounts',
             account: (accountId: string) => `/Accounts/${accountId}`,
             accountSearch: '/Accounts/search',
+            webhooks: '/settings/automation/webhooks',
+            webhook: (webhookId: string) => `/settings/automation/webhooks/${webhookId}`,
         };
     }
 
@@ -321,6 +325,108 @@ export class Api extends OAuth2Requester {
             return await this._get({
                 url: this.baseUrl + this.URLs.accountSearch,
                 query: params,
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * List all webhooks
+     * @param queryParams - Optional query parameters
+     * @returns Promise<any> Webhooks response
+     */
+    async listWebhooks(queryParams: QueryParams = {}): Promise<any> {
+        try {
+            return await this._get({
+                url: this.baseUrl + this.URLs.webhooks,
+                query: queryParams,
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Get specific webhook by ID
+     * @param webhookId - Webhook ID
+     * @returns Promise<any> Webhook details
+     */
+    async getWebhook(webhookId: string): Promise<any> {
+        if (!webhookId) {
+            throw new Error('webhookId is required');
+        }
+        try {
+            return await this._get({
+                url: this.baseUrl + (this.URLs.webhook as (id: string) => string)(webhookId),
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Create new webhook
+     * @param body - Webhook configuration
+     * @returns Promise<any> Created webhook response
+     */
+    async createWebhook(body: any = {}): Promise<any> {
+        if (!body || Object.keys(body).length === 0) {
+            throw new Error('Request body is required');
+        }
+        if (!body.webhooks || !Array.isArray(body.webhooks)) {
+            throw new Error('Body must contain webhooks array');
+        }
+
+        try {
+            return await this._post({
+                url: this.baseUrl + this.URLs.webhooks,
+                body: body,
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Update existing webhook
+     * @param webhookId - Webhook ID to update
+     * @param body - Updated webhook configuration
+     * @returns Promise<any> Updated webhook response
+     */
+    async updateWebhook(webhookId: string, body: any = {}): Promise<any> {
+        if (!webhookId) {
+            throw new Error('webhookId is required');
+        }
+        if (!body || Object.keys(body).length === 0) {
+            throw new Error('Request body is required');
+        }
+        if (!body.webhooks || !Array.isArray(body.webhooks)) {
+            throw new Error('Body must contain webhooks array');
+        }
+
+        try {
+            return await this._put({
+                url: this.baseUrl + (this.URLs.webhook as (id: string) => string)(webhookId),
+                body: body,
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Delete webhook
+     * @param webhookId - Webhook ID to delete
+     * @returns Promise<any> Deletion response
+     */
+    async deleteWebhook(webhookId: string): Promise<any> {
+        if (!webhookId) {
+            throw new Error('webhookId is required');
+        }
+        try {
+            return await this._delete({
+                url: this.baseUrl + (this.URLs.webhook as (id: string) => string)(webhookId),
             });
         } catch (error) {
             throw error;

--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -14,8 +14,13 @@ import {
     AccountsResponse,
     AccountResponse,
     TokenResponse,
-    WebhookConfig,
-    WebhookResponse,
+    ZohoNote,
+    CreateNoteData,
+    NotesResponse,
+    NoteListResponse,
+    NotificationWatchConfig,
+    NotificationResponse,
+    NotificationDetailsResponse,
 } from './types';
 
 export class Api extends OAuth2Requester {
@@ -50,8 +55,7 @@ export class Api extends OAuth2Requester {
             accounts: '/Accounts',
             account: (accountId: string) => `/Accounts/${accountId}`,
             accountSearch: '/Accounts/search',
-            webhooks: '/settings/automation/webhooks',
-            webhook: (webhookId: string) => `/settings/automation/webhooks/${webhookId}`,
+            notificationsWatch: '/actions/watch',
         };
     }
 
@@ -80,6 +84,21 @@ export class Api extends OAuth2Requester {
     async _delete(options: any): Promise<any> {
         const response = await super._delete(options);
         return await this.parsedBody(response);
+    }
+
+    /**
+     * Build URL for notes endpoints with proper encoding
+     * @param module - Module API name (e.g., 'Contacts', 'Leads')
+     * @param recordId - Record ID
+     * @param noteId - Optional note ID for specific note operations
+     * @returns Encoded URL path for notes endpoint
+     */
+    private buildNotesUrl(module: string, recordId: string, noteId?: string): string {
+        const segments = [module, recordId, 'Notes'];
+        if (noteId) segments.push(noteId);
+
+        const encodedPath = segments.map(encodeURIComponent).join('/');
+        return `${this.baseUrl}/${encodedPath}`;
     }
 
     async listUsers(queryParams: QueryParams = {}): Promise<UsersResponse> {
@@ -332,14 +351,22 @@ export class Api extends OAuth2Requester {
     }
 
     /**
-     * List all webhooks
-     * @param queryParams - Optional query parameters
-     * @returns Promise<any> Webhooks response
+     * List all notes for a specific record
+     * @param module - Module API name (Contacts, Leads, Accounts, etc.)
+     * @param recordId - Record ID to get notes for
+     * @param queryParams - Optional query parameters (per_page, page, etc.)
+     * @returns Promise<NoteListResponse> Notes list response
      */
-    async listWebhooks(queryParams: QueryParams = {}): Promise<any> {
+    async listNotes(module: string, recordId: string, queryParams: QueryParams = {}): Promise<NoteListResponse> {
+        if (!module) {
+            throw new Error('module is required');
+        }
+        if (!recordId) {
+            throw new Error('recordId is required');
+        }
         try {
             return await this._get({
-                url: this.baseUrl + this.URLs.webhooks,
+                url: this.buildNotesUrl(module, recordId),
                 query: queryParams,
             });
         } catch (error) {
@@ -348,17 +375,25 @@ export class Api extends OAuth2Requester {
     }
 
     /**
-     * Get specific webhook by ID
-     * @param webhookId - Webhook ID
-     * @returns Promise<any> Webhook details
+     * Get a specific note by ID
+     * @param module - Module API name (Contacts, Leads, Accounts, etc.)
+     * @param recordId - Record ID the note is attached to
+     * @param noteId - Note ID to retrieve
+     * @returns Promise<NotesResponse> Note details
      */
-    async getWebhook(webhookId: string): Promise<any> {
-        if (!webhookId) {
-            throw new Error('webhookId is required');
+    async getNote(module: string, recordId: string, noteId: string): Promise<NotesResponse> {
+        if (!module) {
+            throw new Error('module is required');
+        }
+        if (!recordId) {
+            throw new Error('recordId is required');
+        }
+        if (!noteId) {
+            throw new Error('noteId is required');
         }
         try {
             return await this._get({
-                url: this.baseUrl + (this.URLs.webhook as (id: string) => string)(webhookId),
+                url: this.buildNotesUrl(module, recordId, noteId),
             });
         } catch (error) {
             throw error;
@@ -366,21 +401,33 @@ export class Api extends OAuth2Requester {
     }
 
     /**
-     * Create new webhook
-     * @param body - Webhook configuration
-     * @returns Promise<any> Created webhook response
+     * Create a note for a specific record
+     * @param module - Module API name (Contacts, Leads, Accounts, etc.)
+     * @param recordId - Record ID to attach note to
+     * @param noteData - Note data with Note_Content (required) and optional Note_Title
+     * @returns Promise<NotesResponse> Created note response
      */
-    async createWebhook(body: any = {}): Promise<any> {
-        if (!body || Object.keys(body).length === 0) {
-            throw new Error('Request body is required');
+    async createNote(module: string, recordId: string, noteData: CreateNoteData): Promise<NotesResponse> {
+        if (!module) {
+            throw new Error('module is required');
         }
-        if (!body.webhooks || !Array.isArray(body.webhooks)) {
-            throw new Error('Body must contain webhooks array');
+        if (!recordId) {
+            throw new Error('recordId is required');
         }
+        if (!noteData || !noteData.Note_Content) {
+            throw new Error('noteData.Note_Content is required');
+        }
+
+        const body = {
+            data: [{
+                Note_Content: noteData.Note_Content,
+                ...(noteData.Note_Title && { Note_Title: noteData.Note_Title }),
+            }]
+        };
 
         try {
             return await this._post({
-                url: this.baseUrl + this.URLs.webhooks,
+                url: this.buildNotesUrl(module, recordId),
                 body: body,
             });
         } catch (error) {
@@ -389,25 +436,37 @@ export class Api extends OAuth2Requester {
     }
 
     /**
-     * Update existing webhook
-     * @param webhookId - Webhook ID to update
-     * @param body - Updated webhook configuration
-     * @returns Promise<any> Updated webhook response
+     * Update an existing note
+     * @param module - Module API name (Contacts, Leads, Accounts, etc.)
+     * @param recordId - Record ID the note is attached to
+     * @param noteId - Note ID to update
+     * @param noteData - Updated note data. At least one of Note_Content or Note_Title must be provided.
+     * @returns Promise<NotesResponse> Updated note response
      */
-    async updateWebhook(webhookId: string, body: any = {}): Promise<any> {
-        if (!webhookId) {
-            throw new Error('webhookId is required');
+    async updateNote(module: string, recordId: string, noteId: string, noteData: Partial<CreateNoteData>): Promise<NotesResponse> {
+        if (!module) {
+            throw new Error('module is required');
         }
-        if (!body || Object.keys(body).length === 0) {
-            throw new Error('Request body is required');
+        if (!recordId) {
+            throw new Error('recordId is required');
         }
-        if (!body.webhooks || !Array.isArray(body.webhooks)) {
-            throw new Error('Body must contain webhooks array');
+        if (!noteId) {
+            throw new Error('noteId is required');
         }
+        if (!noteData || (!noteData.Note_Content && !noteData.Note_Title)) {
+            throw new Error('noteData must contain Note_Content or Note_Title');
+        }
+
+        const body = {
+            data: [{
+                ...(noteData.Note_Content && { Note_Content: noteData.Note_Content }),
+                ...(noteData.Note_Title && { Note_Title: noteData.Note_Title }),
+            }]
+        };
 
         try {
             return await this._put({
-                url: this.baseUrl + (this.URLs.webhook as (id: string) => string)(webhookId),
+                url: this.buildNotesUrl(module, recordId, noteId),
                 body: body,
             });
         } catch (error) {
@@ -416,17 +475,100 @@ export class Api extends OAuth2Requester {
     }
 
     /**
-     * Delete webhook
-     * @param webhookId - Webhook ID to delete
-     * @returns Promise<any> Deletion response
+     * Delete a note
+     * @param module - Module API name (Contacts, Leads, Accounts, etc.)
+     * @param recordId - Record ID the note is attached to
+     * @param noteId - Note ID to delete
+     * @returns Promise<NotesResponse> Deletion response
      */
-    async deleteWebhook(webhookId: string): Promise<any> {
-        if (!webhookId) {
-            throw new Error('webhookId is required');
+    async deleteNote(module: string, recordId: string, noteId: string): Promise<NotesResponse> {
+        if (!module) {
+            throw new Error('module is required');
+        }
+        if (!recordId) {
+            throw new Error('recordId is required');
+        }
+        if (!noteId) {
+            throw new Error('noteId is required');
         }
         try {
             return await this._delete({
-                url: this.baseUrl + (this.URLs.webhook as (id: string) => string)(webhookId),
+                url: this.buildNotesUrl(module, recordId, noteId),
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Enable notification channel to receive real-time events
+     * @param body - Notification configuration with watch items
+     * @returns Promise<NotificationResponse> Response with channel details
+     * @see https://www.zoho.com/crm/developer/docs/api/v8/notifications/enable.html
+     */
+    async enableNotification(body: NotificationWatchConfig): Promise<NotificationResponse> {
+        if (!body || !body.watch || !Array.isArray(body.watch)) {
+            throw new Error('Body must contain watch array');
+        }
+
+        // Validate each watch item
+        body.watch.forEach((item, index) => {
+            if (!item.channel_id) {
+                throw new Error(`watch[${index}].channel_id is required`);
+            }
+            if (!item.events || !Array.isArray(item.events) || item.events.length === 0) {
+                throw new Error(`watch[${index}].events must be a non-empty array`);
+            }
+            if (!item.notify_url) {
+                throw new Error(`watch[${index}].notify_url is required`);
+            }
+            if (item.token && item.token.length > 50) {
+                throw new Error(`watch[${index}].token must be 50 characters or less`);
+            }
+        });
+
+        try {
+            return await this._post({
+                url: this.baseUrl + this.URLs.notificationsWatch,
+                body: body,
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Disable notification channels
+     * @param channelIds - Array of channel IDs to disable
+     * @returns Promise<NotificationResponse> Response confirming deletion
+     * @see https://www.zoho.com/crm/developer/docs/api/v8/notifications/disable.html
+     */
+    async disableNotification(channelIds: Array<string | number>): Promise<NotificationResponse> {
+        if (!channelIds || !Array.isArray(channelIds) || channelIds.length === 0) {
+            throw new Error('channelIds must be a non-empty array');
+        }
+
+        try {
+            return await this._delete({
+                url: this.baseUrl + this.URLs.notificationsWatch,
+                query: {
+                    channel_ids: channelIds.join(',')
+                },
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
+     * Get details of all active notification channels
+     * @returns Promise<NotificationDetailsResponse> Details of all active channels
+     * @see https://www.zoho.com/crm/developer/docs/api/v8/notifications/get-details.html
+     */
+    async getNotificationDetails(): Promise<NotificationDetailsResponse> {
+        try {
+            return await this._get({
+                url: this.baseUrl + this.URLs.notificationsWatch,
             });
         } catch (error) {
             throw error;

--- a/packages/v1-ready/zoho-crm/src/types.ts
+++ b/packages/v1-ready/zoho-crm/src/types.ts
@@ -242,3 +242,35 @@ export interface TokenResponse {
     token_type: string;
     expires_in: number;
 }
+
+export interface WebhookConfig {
+    module: string;
+    name: string;
+    url: string;
+    http_method: 'POST' | 'GET';
+    description?: string;
+    authentication?: {
+        type: 'general';
+        authorization_type: 'bearer' | 'basic';
+        authorization_key: string;
+    };
+    module_params?: Array<{
+        name: string;
+        value: string;
+    }>;
+    custom_params?: Array<{
+        name: string;
+        value: string;
+    }>;
+}
+
+export interface WebhookResponse {
+    webhooks: Array<{
+        code: string;
+        details: {
+            id: string;
+        };
+        message: string;
+        status: string;
+    }>;
+}

--- a/packages/v1-ready/zoho-crm/src/types.ts
+++ b/packages/v1-ready/zoho-crm/src/types.ts
@@ -215,6 +215,65 @@ export interface DeleteResponse {
     status: string;
 }
 
+export interface ZohoNote {
+    id: string;
+    Note_Title?: string;
+    Note_Content: string;
+    Parent_Id?: {
+        module: {
+            api_name: string;
+            id: string;
+        };
+        id: string;
+    };
+    Owner?: {
+        name: string;
+        id: string;
+    };
+    Created_Time?: string;
+    Modified_Time?: string;
+    Created_By?: {
+        name: string;
+        id: string;
+    };
+    Modified_By?: {
+        name: string;
+        id: string;
+    };
+    [key: string]: any;
+}
+
+export interface CreateNoteData {
+    Note_Content: string;
+    Note_Title?: string;
+}
+
+export interface NotesResponse {
+    data: Array<{
+        code: string;
+        details: {
+            id: string;
+            Created_Time: string;
+            Modified_Time: string;
+            Created_By?: {
+                name: string;
+                id: string;
+            };
+            Modified_By?: {
+                name: string;
+                id: string;
+            };
+        };
+        message: string;
+        status: string;
+    }>;
+}
+
+export interface NoteListResponse {
+    data: ZohoNote[];
+    info?: PaginationInfo;
+}
+
 export interface QueryParams {
     fields?: string;
     per_page?: number;
@@ -243,34 +302,86 @@ export interface TokenResponse {
     expires_in: number;
 }
 
-export interface WebhookConfig {
-    module: string;
-    name: string;
-    url: string;
-    http_method: 'POST' | 'GET';
-    description?: string;
-    authentication?: {
-        type: 'general';
-        authorization_type: 'bearer' | 'basic';
-        authorization_key: string;
-    };
-    module_params?: Array<{
-        name: string;
-        value: string;
-    }>;
-    custom_params?: Array<{
-        name: string;
-        value: string;
-    }>;
+/**
+ * Configuration for a single notification watch item
+ */
+export interface NotificationWatchItem {
+    /** Unique channel ID (use timestamp or UUID) */
+    channel_id: number | string;
+    /** Events to watch in format: "Module.operation" (e.g., "Contacts.all", "Contacts.create", "Accounts.edit") */
+    events: string[];
+    /** Callback URL to receive notifications */
+    notify_url: string;
+    /** Optional verification token (max 50 characters) */
+    token?: string;
+    /** Channel expiry time (ISO 8601 format, max 1 week from now) */
+    channel_expiry?: string;
+    /** Include field changes in callback payload */
+    return_affected_field_values?: boolean;
+    /** Trigger notifications on related record actions */
+    notify_on_related_action?: boolean;
 }
 
-export interface WebhookResponse {
-    webhooks: Array<{
+/**
+ * Request body for enabling notifications
+ */
+export interface NotificationWatchConfig {
+    watch: NotificationWatchItem[];
+}
+
+/**
+ * Response from notification API operations
+ */
+export interface NotificationResponse {
+    watch: Array<{
         code: string;
         details: {
-            id: string;
+            channel_id: number | string;
+            events: string[];
+            channel_expiry: string;
+            resource_uri: string;
+            resource_id: string;
+            resource_name: string;
         };
         message: string;
         status: string;
     }>;
+}
+
+/**
+ * Response from getting notification details
+ */
+export interface NotificationDetailsResponse {
+    watch: Array<{
+        channel_id: number | string;
+        events: string[];
+        channel_expiry: string;
+        notify_url: string;
+        resource_uri: string;
+        resource_id: string;
+        resource_name: string;
+        token?: string;
+    }>;
+}
+
+/**
+ * Payload received in notification callback
+ */
+export interface NotificationCallbackPayload {
+    /** Server timestamp */
+    server_time: number;
+    /** Module name (e.g., "Contacts", "Accounts") */
+    module: string;
+    /** Resource URI */
+    resource_uri: string;
+    /** Array of affected record IDs */
+    ids: string[];
+    /** Fields that were affected (if return_affected_field_values enabled) */
+    affected_fields?: string[];
+    /** Operation type: "insert", "update", or "delete" */
+    operation: 'insert' | 'update' | 'delete';
+    /** Channel ID that triggered this notification */
+    channel_id: number | string;
+    /** Verification token (if provided during setup) */
+    token?: string;
 }


### PR DESCRIPTION
This pull request adds and enhances webhook management functionality across the Attio, Pipedrive, and Zoho CRM API client packages. The main focus is to provide methods for creating, listing, updating, and deleting webhooks, as well as defining related types. These changes make it easier to manage webhooks programmatically for each integration.

**Webhook Management Enhancements:**

*Attio API (`packages/v1-ready/attio/api.js`):*
- Added a `webhookById` URL helper and a new `updateWebhook` method for updating webhooks by ID. [[1]](diffhunk://#diff-d545ede19d971e67b942e63c6c0ec89d907e23e833966dfe7db36119b578866bR26) [[2]](diffhunk://#diff-d545ede19d971e67b942e63c6c0ec89d907e23e833966dfe7db36119b578866bR219-R229)

*Pipedrive API (`packages/v1-ready/pipedrive/src/api.ts`):*
- Introduced URL helpers for `webhooks` and `webhookById`. [[1]](diffhunk://#diff-ea29ec09744691639b5cbfc98b585a3e181f9b22ae1e1118d046bff8b0f88fb8R30-R31) [[2]](diffhunk://#diff-ea29ec09744691639b5cbfc98b585a3e181f9b22ae1e1118d046bff8b0f88fb8R53-R54)
- Added methods to list all webhooks, create a new webhook, and delete a webhook by ID, with appropriate request/response typing. [[1]](diffhunk://#diff-ea29ec09744691639b5cbfc98b585a3e181f9b22ae1e1118d046bff8b0f88fb8R14) [[2]](diffhunk://#diff-ea29ec09744691639b5cbfc98b585a3e181f9b22ae1e1118d046bff8b0f88fb8R259-R308)

*Zoho CRM API (`packages/v1-ready/zoho-crm/src/api.ts`, `types.ts`):*
- Added URL helpers for webhooks and methods to list, get, create, update, and delete webhooks, including input validation and error handling. [[1]](diffhunk://#diff-de24aed5a7de6e7c70ef3668d0ca2738ebd559f2c6b227f88bad2f351ff3b81aR53-R54) [[2]](diffhunk://#diff-de24aed5a7de6e7c70ef3668d0ca2738ebd559f2c6b227f88bad2f351ff3b81aR333-R434)
- Defined `WebhookConfig` and `WebhookResponse` interfaces for type safety and clarity in webhook operations. [[1]](diffhunk://#diff-de24aed5a7de6e7c70ef3668d0ca2738ebd559f2c6b227f88bad2f351ff3b81aR17-R18) [[2]](diffhunk://#diff-5bd608adbfb626b09a56372297faed0bca6ff70d071db8caeb124fd5104eb95cR245-R276)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-attio@1.1.0-canary.58.42ea316.0
  npm install @friggframework/api-module-pipedrive@2.1.0-canary.58.42ea316.0
  npm install @friggframework/api-module-zoho-crm@1.1.0-canary.58.42ea316.0
  # or 
  yarn add @friggframework/api-module-attio@1.1.0-canary.58.42ea316.0
  yarn add @friggframework/api-module-pipedrive@2.1.0-canary.58.42ea316.0
  yarn add @friggframework/api-module-zoho-crm@1.1.0-canary.58.42ea316.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-attio@1.1.0-next.2`
`@friggframework/api-module-pipedrive@2.1.0-next.2`
`@friggframework/api-module-zoho-crm@2.0.0-next.2`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-attio`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-zoho-crm`
    - feat: Add webhook management functionality to Pipedrive and Zoho CRM API integrations [#58](https://github.com/friggframework/api-module-library/pull/58) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - refactor: zoho crm api module [#57](https://github.com/friggframework/api-module-library/pull/57) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
