### PR TITLE
feat: improve frontify api module

### DIFF
--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -496,20 +496,23 @@ class Api extends OAuth2Requester {
      * Lists collections in a library
      * @param {Object} query - Query parameters
      * @param {string} query.libraryId - ID of the library
-     * @returns {Promise<Object>} List of collections
+     * @param {number} [query.page=1] - Page number
+     * @param {number} [query.limit=25] - Items per page
+     * @returns {Promise<Object>} Paginated list of collections
      */
     async listCollections(query) {
         const ql = `query Collections {
-                    library(id: "${query.libraryId}") {
-                      collections {
-                        items {
-                          id
-                          name
-                          __typename
+                      library(id: "${query.libraryId}") {
+                        collections(${this._paginationParamsQuery(query)}) {
+                          items {
+                            id
+                            name
+                            __typename
+                          }
+                          ${this._paginationPropsQuery()}
                         }
                       }
-                    }
-                  }`;
+                    }`;
 
         const response = await this._post(this.buildRequestOptions(ql));
         this.assertResponse(response);

--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -815,10 +815,50 @@ class Api extends OAuth2Requester {
     }
 
     /**
+     * Lists assets in a subfolder
+     * @param {Object} query - Query parameters
+     * @param {string} query.subFolderId - ID of the subfolder
+     * @param {number} [query.page=1] - Page number
+     * @param {number} [query.limit=25] - Items per page
+     * @returns {Promise<Object>} Paginated list of assets
+     */
+    async listSubFolderAssets(query) {
+        const ql = `query SubFolderAssets {
+                      node(id: "${query.subFolderId}") {
+                        ... on Folder {
+                          assets(${this._paginationParamsQuery(query)}) {
+                            items {
+                              id
+                              title
+                              description
+                              tags { source value }
+                              __typename
+                              ${this._filesQuery()}
+                            }
+                            ${this._paginationPropsQuery()}
+                          }
+                        }
+                      }
+                    }`;
+
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+
+        const {
+            items,
+            total,
+            page,
+            hasNextPage
+        } = response.data.node.assets;
+
+        return { items, total, page, hasNextPage };
+    }
+
+    /**
      * Gets metadata field definitions for a library or project
      * @param {Object} query - Query parameters
      * @param {string} [query.libraryId] - ID of the library
-     * @param {string} [query.projectId] - ID of the project  
+     * @param {string} [query.projectId] - ID of the project
      * @returns {Promise<Object>} Metadata field definitions
      */
     async getMetadataFields(query) {


### PR DESCRIPTION
This pull request enhances the pagination capabilities of the API and introduces a new method for listing assets within subfolders. These changes improve how large datasets are handled and make asset retrieval more flexible.

### Pagination improvements

* The `listCollections` method now supports pagination by accepting optional `page` and `limit` parameters, and returns a paginated list of collections instead of the full set.

### New asset retrieval functionality

* Added a new `listSubFolderAssets` method that lists assets within a specified subfolder, supporting pagination via `page` and `limit` parameters. The method returns paginated asset data including metadata and file information.