### PR TITLE
feat: enhance asset handling with multi-select support and add delete asset functionality

### DIFF
--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -914,10 +914,11 @@ class Api extends OAuth2Requester {
               case 'CustomMetadataPropertyTypeDate':
                   return 'date';
               case 'CustomMetadataPropertyTypeSelect':
-              case 'CustomMetadataPropertyTypeMultiSelect':
                   return 'select';
+              case 'CustomMetadataPropertyTypeMultiSelect':
+                  return 'multiselect';
               case 'CustomMetadataPropertyTypeUrl':
-                  return 'string';
+                  return 'url';
               default:
                   return 'string';
           }
@@ -970,13 +971,13 @@ class Api extends OAuth2Requester {
   
           const metadataItems = entries
               .filter((e) => e && e.propertyId && e.value !== undefined && e.value !== null && e.value !== '')
-              .map((e) => {
+              .flatMap((e) => {
                   if (Array.isArray(e.value)) {
-                      const values = e.value
+                      // For multi-select, create separate entries for each selected value
+                      return e.value
                           .map((v) => normalizeValue(v))
                           .filter((v) => v !== null)
-                          .join(', ');
-                      return `{ propertyId: "${e.propertyId}", values: [ ${values} ] }`;
+                          .map((v) => `{ propertyId: "${e.propertyId}", value: ${v} }`);
                   }
                   const coerced = normalizeValue(e.value);
                   return `{ propertyId: "${e.propertyId}", value: ${coerced} }`;
@@ -1263,6 +1264,27 @@ class Api extends OAuth2Requester {
         this.assertResponse(response);
         return {
             id: response.data.createAsset.job.assetId
+        };
+    }
+
+    /**
+     * Deletes an existing asset
+     * @param {string} assetId - ID of the asset to delete
+     * @returns {Promise<Object>} Deleted asset ID
+     */
+    async deleteAsset(assetId) {
+        const ql = `mutation DeleteAsset {
+                      deleteAsset(input: {
+                        id: "${assetId}"
+                      }) {
+                        id
+                      }
+                    }`;
+
+        const response = await this._post(this.buildRequestOptions(ql));
+        this.assertResponse(response);
+        return {
+            id: response.data.deleteAsset.id
         };
     }
 


### PR DESCRIPTION
This pull request updates the `Api` class in `packages/v1-ready/frontify/api.js` to improve metadata handling and add asset management functionality. The most notable changes include more accurate mapping of custom metadata property types, enhanced processing of multi-select metadata values, and the introduction of a method for deleting assets.

**Metadata property type mapping improvements:**
* Updated the mapping for `CustomMetadataPropertyTypeMultiSelect` to return `'multiselect'` instead of `'select'`, and for `CustomMetadataPropertyTypeUrl` to return `'url'` instead of `'string'`, ensuring more accurate type handling.

**Metadata value processing enhancements:**
* Changed the processing of metadata entries to use `.flatMap()`, so that multi-select values generate separate entries for each selected value, improving downstream data handling.

**Asset management:**
* Added a new `deleteAsset(assetId)` method to allow deletion of assets by ID, expanding the API's asset management capabilities.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-frontify@2.0.0-next.13`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-frontify`
    - feat: enhance asset handling with multi-select support and add delete asset functionality [#62](https://github.com/friggframework/api-module-library/pull/62) ([@d-klotz](https://github.com/d-klotz))
    - feat: improve frontify api module [#59](https://github.com/friggframework/api-module-library/pull/59) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Feat: add scope to Frontify token refresh request [#61](https://github.com/friggframework/api-module-library/pull/61) ([@d-klotz](https://github.com/d-klotz))
    - feat: Add webhook management functionality to Pipedrive and Zoho CRM API integrations [#58](https://github.com/friggframework/api-module-library/pull/58) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - chore: trigger release [#60](https://github.com/friggframework/api-module-library/pull/60) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
