### PR TITLE
Fix/json header update activities

### DIFF
--- a/packages/v1-ready/pipedrive/src/api.ts
+++ b/packages/v1-ready/pipedrive/src/api.ts
@@ -200,9 +200,6 @@ export class Api extends OAuth2Requester {
   }
 
   async createActivity(params: ActivityParams): Promise<PipedriveResponse> {
-    const dealId = get(params, "dealId", null);
-    const subject = get(params, "subject");
-    const type = get(params, "type");
     const options: RequestOptions = {
       url: this.baseUrl + this.URLs.activities,
       body: { ...params },

--- a/packages/v1-ready/pipedrive/src/api.ts
+++ b/packages/v1-ready/pipedrive/src/api.ts
@@ -192,6 +192,9 @@ export class Api extends OAuth2Requester {
     const options: RequestOptions = {
       url: this.baseUrl + this.URLs.activityById(activityId),
       body: task,
+      headers: {
+        "Content-Type": "application/json",
+      },
     };
     return this._patch(options);
   }


### PR DESCRIPTION
Pipedrive: Enriching an activity with a Summary goes wrong:

```
  POST using createActivity which has the Content-Type header.

  But updateActivity (PATCH) is missing it:

  // createActivity - line 132-143
  async createActivity(params) {
      const options = {
          url: this.baseUrl + this.URLs.activities,
          body: { ...params },
          headers: {
              "Content-Type": "application/json",  // ✅ Has it
          },
      };
      return this._post(options);
  }

  // updateActivity - line 125-131
  async updateActivity(activityId, task) {
      const options = {
          url: this.baseUrl + this.URLs.activityById(activityId),
          body: task,
          // ❌ No Content-Type header!
      };
      return this._patch(options);
  }

  Summary:
  ┌────────────────────────┬──────────────────┬────────┐
  │         Method         │ Has Content-Type │ Works  │
  ├────────────────────────┼──────────────────┼────────┤
  │ createActivity (POST)  │ ✅ Yes           │ ✅ Yes │
  ├────────────────────────┼──────────────────┼────────┤
  │ updateActivity (PATCH) │ ❌ No            │ ❌ No  │
  └────────────────────────┴──────────────────┴────────┘
  ```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-pipedrive@2.0.1-canary.69.35c10f7.0
  # or 
  yarn add @friggframework/api-module-pipedrive@2.0.1-canary.69.35c10f7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-pipedrive@2.1.0-next.4`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Roberto Oliveros ([@roboli](https://github.com/roboli)), for all your work!
  
  #### 🚀 Enhancement
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat(zoho-crm): add multi-datacenter support [#68](https://github.com/friggframework/api-module-library/pull/68) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-pipedrive`
    - Fix/json header update activities [#69](https://github.com/friggframework/api-module-library/pull/69) ([@roboli](https://github.com/roboli))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
