### PR TITLE
refactor(api-modules): rename identifiers.user to identifiers.userId

### DIFF
--- a/packages/needs-updating/slack/definition.js
+++ b/packages/needs-updating/slack/definition.js
@@ -40,7 +40,7 @@ const Definition = {
                 api.authed_user.id : api.teamId;
 
             return {
-                identifiers: {externalId, user: userId},
+                identifiers: {externalId, userId},
                 details: {name: api.team_name}
             }
         },

--- a/packages/v1-ready/42matters/definition.js
+++ b/packages/v1-ready/42matters/definition.js
@@ -15,7 +15,7 @@ const Definition = {
         },
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             return {
-                identifiers: {externalId: md5(api.access_token), user: userId},
+                identifiers: {externalId: md5(api.access_token), userId},
                 details: {},
             }
         },
@@ -25,7 +25,7 @@ const Definition = {
         },
         getCredentialDetails: async function (api, userId) {
             return {
-                identifiers: {externalId: md5(api.access_token), user: userId},
+                identifiers: {externalId: md5(api.access_token), userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/asana/definition.js
+++ b/packages/v1-ready/asana/definition.js
@@ -31,7 +31,7 @@ const Definition = {
         getCredentialDetails: async function (api, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: userDetails.portalId, userId},
+                identifiers: {externalId: userDetails.sub, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/asana/definition.js
+++ b/packages/v1-ready/asana/definition.js
@@ -18,7 +18,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: userDetails.sub, user: userId},
+                identifiers: {externalId: userDetails.sub, userId},
                 details: {name: userDetails.name, email: userDetails.email},
             }
         },
@@ -31,7 +31,7 @@ const Definition = {
         getCredentialDetails: async function (api, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: userDetails.portalId, user: userId},
+                identifiers: {externalId: userDetails.portalId, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/attio/definition.js
+++ b/packages/v1-ready/attio/definition.js
@@ -24,7 +24,7 @@ const Definition = {
             }
 
             return {
-                identifiers: {externalId: tokenInfo.workspace_id, user: userId},
+                identifiers: {externalId: tokenInfo.workspace_id, userId},
                 details: {name: tokenInfo.workspace_name || tokenInfo.workspace_slug},
             }
         },
@@ -45,7 +45,7 @@ const Definition = {
             }
 
             return {
-                identifiers: {externalId: tokenInfo.workspace_id, user: userId},
+                identifiers: {externalId: tokenInfo.workspace_id, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/connectwise/definition.js
+++ b/packages/v1-ready/connectwise/definition.js
@@ -27,7 +27,7 @@ const Definition = {
         },
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             return {
-                identifiers: {externalId: api.company_id, user: userId},
+                identifiers: {externalId: api.company_id, userId},
                 details: {},
             }
         },
@@ -37,7 +37,7 @@ const Definition = {
         },
         getCredentialDetails: async function (api, userId) {
             return {
-                identifiers: {externalId: api.company_id, user: userId},
+                identifiers: {externalId: api.company_id, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/contentful/definition.js
+++ b/packages/v1-ready/contentful/definition.js
@@ -22,7 +22,7 @@ const Definition = {
                 name: space.name
             }));
             return {
-                identifiers: {externalId: entityDetails.identifier, user: userId},
+                identifiers: {externalId: entityDetails.identifier, userId},
                 details: {
                     name: entityDetails.name,
                     spaces,
@@ -39,7 +39,7 @@ const Definition = {
         getCredentialDetails: async function (api, userId) {
             const userDetails = await api.getTokenIdentity();
             return {
-                identifiers: {externalId: userDetails.identifier, user: userId},
+                identifiers: {externalId: userDetails.identifier, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/contentstack/definition.js
+++ b/packages/v1-ready/contentstack/definition.js
@@ -29,13 +29,13 @@ const Definition = {
             const externalId = api.api_key;
             const name = roles[0].stack.name;
             return {
-                identifiers: {externalId, user: userId},
+                identifiers: {externalId, userId},
                 details: {name}
             }
         },
         getCredentialDetails: async function (api, userId) {
             return {
-                identifiers: {externalId: api.api_key, user: userId},
+                identifiers: {externalId: api.api_key, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/crossbeam/definition.js
+++ b/packages/v1-ready/crossbeam/definition.js
@@ -23,7 +23,7 @@ const Definition = {
     ) {
       const userDetails = await api.getUserDetails();
       return {
-        identifiers: { externalId: userDetails.portalId, user: userId },
+        identifiers: { externalId: userDetails.portalId, userId },
         details: { name: userDetails.hub_domain },
       };
     },
@@ -34,7 +34,7 @@ const Definition = {
     getCredentialDetails: async function (api, userId) {
       const userDetails = await api.getUserDetails();
       return {
-        identifiers: { externalId: userDetails.portalId, user: userId },
+        identifiers: { externalId: userDetails.portalId, userId },
         details: {},
       };
     },

--- a/packages/v1-ready/deel/definition.js
+++ b/packages/v1-ready/deel/definition.js
@@ -18,7 +18,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const tokenDetails = await api.getTokenIdentity();
             return {
-                identifiers: {externalId: tokenDetails.id, user: userId},
+                identifiers: {externalId: tokenDetails.id, userId},
                 details: {name: tokenDetails.name},
             }
         },

--- a/packages/v1-ready/frigg-scale-test/src/defintion.ts
+++ b/packages/v1-ready/frigg-scale-test/src/defintion.ts
@@ -64,7 +64,7 @@ const definition: FriggModuleAuthDefinition = {
       return {
         identifiers: {
           externalId: "scale-test-account",
-          user: userId,
+          userId,
         },
         details: {
           name: "Scale Test Account",
@@ -80,7 +80,7 @@ const definition: FriggModuleAuthDefinition = {
       return {
         identifiers: {
           externalId: "scale-test-account",
-          user: userId,
+          userId,
         },
         details: {},
       };

--- a/packages/v1-ready/frontify/definition.js
+++ b/packages/v1-ready/frontify/definition.js
@@ -46,7 +46,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const {user: userDetails} = await api.getUser();
             return {
-                identifiers: {externalId: userDetails.id, user: userId},
+                identifiers: {externalId: userDetails.id, userId},
                 details: {name: userDetails.name },
             }
         },
@@ -59,7 +59,7 @@ const Definition = {
         getCredentialDetails: async function (api, userId) {
             const {user: userDetails} = await api.getUser();
             return {
-                identifiers: {externalId: userDetails.id, user: userId},
+                identifiers: {externalId: userDetails.id, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/google-calendar/definition.js
+++ b/packages/v1-ready/google-calendar/definition.js
@@ -17,7 +17,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const entityDetails = await api.getTokenIdentity();
             return {
-                identifiers: {externalId: entityDetails.identifier, user: userId},
+                identifiers: {externalId: entityDetails.identifier, userId},
                 details: {name: entityDetails.name},
             }
         },

--- a/packages/v1-ready/helpscout/definition.js
+++ b/packages/v1-ready/helpscout/definition.js
@@ -21,7 +21,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const entityDetails = await api.getTokenIdentity();
             return {
-                identifiers: {externalId: entityDetails.identifier, user: userId},
+                identifiers: {externalId: entityDetails.identifier, userId},
                 details: {name: entityDetails.name},
             }
         },

--- a/packages/v1-ready/hubspot/definition.js
+++ b/packages/v1-ready/hubspot/definition.js
@@ -18,7 +18,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: userDetails.portalId, user: userId},
+                identifiers: {externalId: userDetails.portalId, userId},
                 details: {name: userDetails.hub_domain},
             }
         },
@@ -31,7 +31,7 @@ const Definition = {
         getCredentialDetails: async function (api, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: userDetails.portalId, user: userId},
+                identifiers: {externalId: userDetails.portalId, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/ironclad/definition.js
+++ b/packages/v1-ready/ironclad/definition.js
@@ -24,7 +24,7 @@ const Definition = {
             }
             const user = await api.getUserDetails();
             return {
-                identifiers: { externalId: user.id, user: userId },
+                identifiers: { externalId: user.id, userId },
                 details: { name: user.displayName, email: user.email },
             };
         },
@@ -42,7 +42,7 @@ const Definition = {
             }
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: { externalId: userDetails.portalId, user: userId },
+                identifiers: { externalId: userDetails.portalId, userId },
                 details: {},
             };
         },

--- a/packages/v1-ready/linear/definition.js
+++ b/packages/v1-ready/linear/definition.js
@@ -21,7 +21,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const entityDetails = await api.getTokenIdentity();
             return {
-                identifiers: {externalId: entityDetails.identifier, user: userId},
+                identifiers: {externalId: entityDetails.identifier, userId},
                 details: {name: entityDetails.name},
             }
         },

--- a/packages/v1-ready/pipedrive/frigg-core.d.ts
+++ b/packages/v1-ready/pipedrive/frigg-core.d.ts
@@ -12,14 +12,14 @@ declare module '@friggframework/core' {
         tokenResponse: any,
         userId: string
       ) => Promise<{
-        identifiers: { externalId: string; user: string };
+        identifiers: { externalId: string; userId: string };
         details: Record<string, any>;
       }>;
       getCredentialDetails?: (
         api: any,
         userId: string
       ) => Promise<{
-        identifiers: { externalId: string; user: string };
+        identifiers: { externalId: string; userId: string };
         details: Record<string, any>;
       }>;
       apiPropertiesToPersist?: {

--- a/packages/v1-ready/pipedrive/src/definition.ts
+++ b/packages/v1-ready/pipedrive/src/definition.ts
@@ -36,7 +36,7 @@ const Definition: FriggModuleAuthDefinition = {
         return {
           identifiers: {
             externalId: String(userProfile.data.company_id),
-            user: userId,
+            userId,
           },
           details: {
             name: userProfile.data.company_name || "Unknown Company",
@@ -68,7 +68,7 @@ const Definition: FriggModuleAuthDefinition = {
         return {
           identifiers: {
             externalId: String(userProfile.data.id),
-            user: userId,
+            userId,
           },
           details: {},
         };

--- a/packages/v1-ready/salesforce/definition.js
+++ b/packages/v1-ready/salesforce/definition.js
@@ -36,7 +36,7 @@ const Definition = {
             const orgDetails = orgResponse[0];
             const { Username: connectedUsername } = await api.getUserInfo();
             return {
-                identifiers: { externalId: orgDetails.Id, user: userId },
+                identifiers: { externalId: orgDetails.Id, userId },
                 details: { name: orgDetails.Name, connectedUsername },
             };
         },
@@ -48,7 +48,7 @@ const Definition = {
         },
         getCredentialDetails: async function (api, userId) {
             return {
-                identifiers: { instanceUrl: api.instanceUrl, user: userId },
+                identifiers: { instanceUrl: api.instanceUrl, userId },
                 details: {}
             };
         },

--- a/packages/v1-ready/salesforce/manager.js
+++ b/packages/v1-ready/salesforce/manager.js
@@ -113,7 +113,7 @@ class Manager extends ModuleManager {
 
         const createObj = {
             credential: this.credential.id,
-            user: this.userId,
+            userId: this.userId,
             name,
             externalId,
             isSandbox,
@@ -121,7 +121,7 @@ class Manager extends ModuleManager {
         };
         this.entity = await Entity.findOneAndUpdate(
             {
-                user: this.userId,
+                userId: this.userId,
                 externalId,
                 isSandbox,
             },
@@ -170,7 +170,7 @@ class Manager extends ModuleManager {
                     };
                     this.credential = await Credential.findOneAndUpdate(
                         {
-                            user: this.userId,
+                            userId: this.userId,
                             instanceUrl: this.api.instanceUrl,
                         },
                         updatedToken,

--- a/packages/v1-ready/stripe/definition.js
+++ b/packages/v1-ready/stripe/definition.js
@@ -20,7 +20,7 @@ const Definition = {
             const accountDetails = await api.getAccountDetails();
             if (userId.userId) userId = userId.userId;
             return {
-                identifiers: { externalId: accountDetails.id, user: userId },
+                identifiers: { externalId: accountDetails.id, userId },
                 details: {
                     name: accountDetails.business_profile?.name,
                     email: accountDetails.email,
@@ -37,7 +37,7 @@ const Definition = {
             const accountDetails = await api.getAccountDetails();
             if (userId.userId) userId = userId.userId;
             return {
-                identifiers: { externalId: accountDetails.id, user: userId },
+                identifiers: { externalId: accountDetails.id, userId },
                 details: {},
             };
         },

--- a/packages/v1-ready/unbabel-projects/definition.js
+++ b/packages/v1-ready/unbabel-projects/definition.js
@@ -38,13 +38,13 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const externalId = api.customer_id;
             return {
-                identifiers: {externalId, user: userId},
+                identifiers: {externalId, userId},
                 details: {name: api.username}
             }
         },
         getCredentialDetails: async function (api, userId) {
             return {
-                identifiers: {externalId: api.customer_id, user: userId},
+                identifiers: {externalId: api.customer_id, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/unbabel-projects/manager.js
+++ b/packages/v1-ready/unbabel-projects/manager.js
@@ -133,7 +133,7 @@ class Manager extends ModuleManager {
             if (credentialSearch.length > 1) {
                 debug(`Multiple credentials found with same identifier: ${userDetails.identifier}`);
                 this.throwException(`Multiple credentials found with same identifier: ${userDetails.identifier}`);
-            } else if (credentialSearch === 1 && credentialSearch[0].user !== this.userId) {
+            } else if (credentialSearch === 1 && credentialSearch[0].userId !== this.userId) {
                 debug(`A credential already exists with this identifier: ${userDetails.identifier}`);
                 this.throwException(`A credential already exists with this identifier: ${userDetails.identifier}`);
             } else if (credentialSearch === 1) {

--- a/packages/v1-ready/unbabel-projects/manager.js
+++ b/packages/v1-ready/unbabel-projects/manager.js
@@ -78,7 +78,7 @@ class Manager extends ModuleManager {
         const name = get(params, 'name');
 
         const search = await Entity.find({
-            user: this.userId,
+            userId: this.userId,
             externalId: identifier,
         });
         if (search.length === 0) {
@@ -86,7 +86,7 @@ class Manager extends ModuleManager {
             // create entity
             const createObj = {
                 credential: this.credential.id,
-                user: this.userId,
+                userId: this.userId,
                 name,
                 externalId: identifier,
             };
@@ -114,7 +114,7 @@ class Manager extends ModuleManager {
     async updateOrCreateCredential() {
         const userDetails = await this.api.getTokenIdentity();
         const updatedToken = {
-            user: this.userId.toString(),
+            userId: this.userId.toString(),
             auth_is_valid: true,
         };
         if (this.access_token) {

--- a/packages/v1-ready/unbabel/definition.js
+++ b/packages/v1-ready/unbabel/definition.js
@@ -38,13 +38,13 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const externalId = api.customer_id;
             return {
-                identifiers: {externalId, user: userId},
+                identifiers: {externalId, userId},
                 details: {name: api.username}
             }
         },
         getCredentialDetails: async function (api, userId) {
             return {
-                identifiers: {externalId: api.customer_id, user: userId},
+                identifiers: {externalId: api.customer_id, userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/zoho-crm/src/definition.ts
+++ b/packages/v1-ready/zoho-crm/src/definition.ts
@@ -34,7 +34,7 @@ export const Definition = {
             const response = await api.listUsers({type: 'CurrentUser'});
             const currentUser = response.users[0];
             return {
-                identifiers: {externalId: currentUser.id, user: userId},
+                identifiers: {externalId: currentUser.id, userId},
                 details: {},
             };
         },
@@ -42,7 +42,7 @@ export const Definition = {
             const response = await api.listUsers({type: 'CurrentUser'});
             const currentUser = response.users[0];
             return {
-                identifiers: {externalId: currentUser.id, user: userId},
+                identifiers: {externalId: currentUser.id, userId},
                 details: {
                     name: currentUser.email,
                     location: api.location,

--- a/packages/v1-ready/zoom/definition.js
+++ b/packages/v1-ready/zoom/definition.js
@@ -23,7 +23,7 @@ const Definition = {
     ) {
       const userDetails = await api.getUserDetails();
       return {
-        identifiers: { externalId: userDetails.id, user: userId },
+        identifiers: { externalId: userDetails.id, userId },
         details: { name: userDetails.display_name },
       };
     },
@@ -34,7 +34,7 @@ const Definition = {
     getCredentialDetails: async function (api, userId) {
       const userDetails = await api.getUserDetails();
       return {
-        identifiers: { externalId: userDetails.id, user: userId },
+        identifiers: { externalId: userDetails.id, userId },
         details: {},
       };
     },


### PR DESCRIPTION
## Summary
- Update all API modules to use `userId` instead of `user` in credential identifiers objects
- This aligns with the database schema column name (`userId`)
- Removes the need for backward compatibility mapping in repositories

## Affected Modules (19 files)
- 42matters, asana, connectwise, contentful, contentstack
- crossbeam, deel, google-calendar, helpscout, hubspot  
- ironclad, linear, salesforce, stripe, unbabel
- unbabel-projects, zoom

## Test Plan
- [ ] Verify API modules still work with credential upsert operations
- [ ] Test token refresh flow for affected modules

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-slack@1.1.4-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-42matters@1.1.5-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-asana@1.1.6-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-attio@1.0.1-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-connectwise@1.0.5-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-contentful@1.1.4-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-contentstack@1.1.4-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-crossbeam@1.0.1-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-deel@1.1.4-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-frigg-scale-test@0.1.1-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-frontify@1.3.1-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-google-calendar@1.1.4-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-helpscout@0.1.3-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-hubspot@1.1.8-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-ironclad@1.0.2-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-linear@1.1.4-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-pipedrive@2.0.1-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-salesforce@1.0.3-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-stripe@1.0.1-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-unbabel@1.1.6-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-unbabel-projects@1.0.3-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-zoho-crm@1.0.3-canary.70.ccaa8dc.0
  npm install @friggframework/api-module-zoom@1.0.1-canary.70.ccaa8dc.0
  # or 
  yarn add @friggframework/api-module-slack@1.1.4-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-42matters@1.1.5-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-asana@1.1.6-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-attio@1.0.1-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-connectwise@1.0.5-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-contentful@1.1.4-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-contentstack@1.1.4-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-crossbeam@1.0.1-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-deel@1.1.4-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-frigg-scale-test@0.1.1-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-frontify@1.3.1-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-google-calendar@1.1.4-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-helpscout@0.1.3-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-hubspot@1.1.8-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-ironclad@1.0.2-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-linear@1.1.4-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-pipedrive@2.0.1-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-salesforce@1.0.3-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-stripe@1.0.1-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-unbabel@1.1.6-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-unbabel-projects@1.0.3-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-zoho-crm@1.0.3-canary.70.ccaa8dc.0
  yarn add @friggframework/api-module-zoom@1.0.1-canary.70.ccaa8dc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-42matters@2.0.0-next.1`
`@friggframework/api-module-asana@2.0.0-next.6`
`@friggframework/api-module-attio@1.1.0-next.3`
`@friggframework/api-module-connectwise@2.0.0-next.1`
`@friggframework/api-module-contentful@2.0.0-next.1`
`@friggframework/api-module-contentstack@2.0.0-next.1`
`@friggframework/api-module-crossbeam@2.0.0-next.1`
`@friggframework/api-module-deel@2.0.0-next.1`
`@friggframework/api-module-frigg-scale-test@0.2.0-next.5`
`@friggframework/api-module-frontify@2.0.0-next.17`
`@friggframework/api-module-google-calendar@2.0.0-next.1`
`@friggframework/api-module-helpscout@1.0.0-next.1`
`@friggframework/api-module-hubspot@2.0.0-next.2`
`@friggframework/api-module-ironclad@2.0.0-next.1`
`@friggframework/api-module-linear@2.0.0-next.1`
`@friggframework/api-module-pipedrive@2.1.0-next.5`
`@friggframework/api-module-salesforce@2.0.0-next.2`
`@friggframework/api-module-slack@2.0.0-next.1`
`@friggframework/api-module-stripe@2.0.0-next.1`
`@friggframework/api-module-unbabel-projects@2.0.0-next.1`
`@friggframework/api-module-unbabel@2.0.0-next.1`
`@friggframework/api-module-zoho-crm@2.0.0-next.5`
`@friggframework/api-module-zoom@2.0.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - refactor(api-modules): rename identifiers.user to identifiers.userId [#70](https://github.com/friggframework/api-module-library/pull/70) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Fix/json header update activities [#69](https://github.com/friggframework/api-module-library/pull/69) ([@roboli](https://github.com/roboli))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
