### PR TITLE
feat(zoho-crm): add updateNotification method for channel renewal

### DIFF
--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -619,6 +619,44 @@ export class Api extends OAuth2Requester {
     }
 
     /**
+     * Update/renew notification channel configuration
+     * Use this to extend the channel_expiry before it expires (max 7 days from now)
+     * @param body - Notification configuration with watch items to update
+     * @returns Promise<NotificationResponse> Response with updated channel details
+     * @see https://www.zoho.com/crm/developer/docs/api/v8/notifications/update.html
+     */
+    async updateNotification(body: NotificationWatchConfig): Promise<NotificationResponse> {
+        if (!body || !body.watch || !Array.isArray(body.watch)) {
+            throw new Error('Body must contain watch array');
+        }
+
+        // Validate each watch item
+        body.watch.forEach((item, index) => {
+            if (!item.channel_id) {
+                throw new Error(`watch[${index}].channel_id is required`);
+            }
+            if (!item.events || !Array.isArray(item.events) || item.events.length === 0) {
+                throw new Error(`watch[${index}].events must be a non-empty array`);
+            }
+            if (!item.notify_url) {
+                throw new Error(`watch[${index}].notify_url is required`);
+            }
+            if (item.token && item.token.length > 50) {
+                throw new Error(`watch[${index}].token must be 50 characters or less`);
+            }
+        });
+
+        try {
+            return await this._patch({
+                url: this.baseUrl + this.URLs.notificationsWatch,
+                body: body,
+            });
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    /**
      * Disable notification channels
      * @param channelIds - Array of channel IDs to disable
      * @returns Promise<NotificationResponse> Response confirming deletion

--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -43,6 +43,15 @@ const LOCATION_CONFIG: Record<ZohoLocation, { accounts: string; api: string }> =
 
 const DEFAULT_LOCATION: ZohoLocation = 'us';
 
+/**
+ * Formats datetime for Zoho API (removes milliseconds, converts Z to +00:00)
+ * Zoho expects format: 2019-05-02T15:00:00+05:30
+ */
+function formatDateTimeForZoho(dateStr: string | undefined): string | undefined {
+    if (!dateStr) return dateStr;
+    return dateStr.replace(/\.\d{3}Z$/, '+00:00').replace(/Z$/, '+00:00');
+}
+
 export class Api extends OAuth2Requester {
     public URLs: Record<string, string | ((id: string) => string)>;
     public location: ZohoLocation;
@@ -608,10 +617,18 @@ export class Api extends OAuth2Requester {
             }
         });
 
+        const formattedBody: NotificationWatchConfig = {
+            ...body,
+            watch: body.watch.map(item => ({
+                ...item,
+                ...(item.channel_expiry && { channel_expiry: formatDateTimeForZoho(item.channel_expiry) })
+            }))
+        };
+
         try {
             return await this._post({
                 url: this.baseUrl + this.URLs.notificationsWatch,
-                body: body,
+                body: formattedBody,
             });
         } catch (error) {
             throw error;
@@ -646,10 +663,18 @@ export class Api extends OAuth2Requester {
             }
         });
 
+        const formattedBody: NotificationWatchConfig = {
+            ...body,
+            watch: body.watch.map(item => ({
+                ...item,
+                ...(item.channel_expiry && { channel_expiry: formatDateTimeForZoho(item.channel_expiry) })
+            }))
+        };
+
         try {
             return await this._patch({
                 url: this.baseUrl + this.URLs.notificationsWatch,
-                body: body,
+                body: formattedBody,
             });
         } catch (error) {
             throw error;

--- a/packages/v1-ready/zoho-crm/src/frigg-core.d.ts
+++ b/packages/v1-ready/zoho-crm/src/frigg-core.d.ts
@@ -16,6 +16,7 @@ declare module '@friggframework/core' {
         parsedBody(response: any): Promise<any>;
         _get(options: any, stringify?: boolean): Promise<any>;
         _post(options: any, stringify?: boolean): Promise<any>;
+        _patch(options: any): Promise<any>;
         _put(options: any, stringify?: boolean): Promise<any>;
         _delete(options: any): Promise<any>;
     }


### PR DESCRIPTION
## Summary

- Add `updateNotification()` method to Zoho CRM API module for renewing notification channels
- Enables automatic webhook renewal before expiration (max 7 days for Zoho channels)

## Changes

### `packages/v1-ready/zoho-crm/src/api.ts`

**New Method: `updateNotification(body: NotificationWatchConfig)`**
- Uses PATCH method on `/crm/v8/actions/watch` endpoint
- Same validation as `enableNotification()`:
  - `channel_id` required
  - `events` must be non-empty array
  - `notify_url` required
  - `token` max 50 characters
- Returns `Promise<NotificationResponse>` with updated channel details

## API Documentation

Zoho CRM Notifications Update API:
https://www.zoho.com/crm/developer/docs/api/v8/notifications/update.html

## Usage Example

```typescript
const zohoApi = new Api(params);

// Renew notification channel before it expires
await zohoApi.updateNotification({
    watch: [{
        channel_id: existingChannelId,
        events: ['Contacts.all', 'Accounts.all'],
        channel_expiry: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
        token: verificationToken,
        notify_url: webhookUrl,
    }],
});
```

## Method Comparison

| Method | HTTP | Purpose |
|--------|------|---------|
| `enableNotification()` | POST | Create new notification channel |
| `updateNotification()` | PATCH | Update/renew existing channel |
| `disableNotification()` | DELETE | Remove notification channel |
| `getNotificationDetails()` | GET | List active channels |

## Test Plan

- [ ] Unit test for updateNotification validation
- [ ] Integration test with mock server
- [ ] Manual test against Zoho CRM sandbox

## Related

This enables automatic webhook renewal in Zoho CRM integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-zoho-crm@1.1.0-canary.71.08b1c2c.0
  # or 
  yarn add @friggframework/api-module-zoho-crm@1.1.0-canary.71.08b1c2c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-zoho-crm@2.0.0-next.7`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-zoho-crm`
    - feat(zoho-crm): add updateNotification method for channel renewal [#71](https://github.com/friggframework/api-module-library/pull/71) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix(zoho-crm): remove accountsServer in favor of location-based token URLs [#73](https://github.com/friggframework/api-module-library/pull/73) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - refactor(api-modules): rename identifiers.user to identifiers.userId [#70](https://github.com/friggframework/api-module-library/pull/70) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
