### PR TITLE
fix(zoho-crm): remove accountsServer in favor of location-based token URLs

### DIFF
--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -122,13 +122,8 @@ export class Api extends OAuth2Requester {
             headers: (formData as any).getHeaders(),
             url: this.tokenUri,
         };
-        //log client_id and secret
-        console.log("[zoho]: client_id is: ", this.client_id);
-        console.log("[zoho]: client_secret is: ", this.client_secret);
-        console.log("[zoho]: token URL is: ", this.tokenUri);
         
         const response = await this._post(options, false);
-        console.log("[zoho]: Token response from getTokenFromCode:", JSON.stringify(response));
         await this.setTokens(response);
         return response;
     }

--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -122,6 +122,9 @@ export class Api extends OAuth2Requester {
             headers: (formData as any).getHeaders(),
             url: this.tokenUri,
         };
+        //log client_id and secret
+        console.log("[zoho]: client_id is: ", this.client_id);
+        console.log("[zoho]: client_secret is: ", this.client_secret);
         console.log("[zoho]: token URL is: ", this.tokenUri);
         
         const response = await this._post(options, false);

--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -122,7 +122,10 @@ export class Api extends OAuth2Requester {
             headers: (formData as any).getHeaders(),
             url: this.tokenUri,
         };
+        console.log("[zoho]: token URL is: ", this.tokenUri);
+        
         const response = await this._post(options, false);
+        console.log("[zoho]: Token response from getTokenFromCode:", JSON.stringify(response));
         await this.setTokens(response);
         return response;
     }

--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -36,7 +36,7 @@ const LOCATION_CONFIG: Record<ZohoLocation, { accounts: string; api: string }> =
     in: { accounts: 'https://accounts.zoho.in', api: 'https://www.zohoapis.in' },
     au: { accounts: 'https://accounts.zoho.com.au', api: 'https://www.zohoapis.com.au' },
     cn: { accounts: 'https://accounts.zoho.com.cn', api: 'https://www.zohoapis.com.cn' },
-    ca: { accounts: 'https://accounts.zoho.ca', api: 'https://www.zohoapis.ca' },
+    ca: { accounts: 'https://accounts.zohocloud.ca', api: 'https://www.zohoapis.ca' },
     jp: { accounts: 'https://accounts.zoho.jp', api: 'https://www.zohoapis.jp' },
     sa: { accounts: 'https://accounts.zoho.sa', api: 'https://www.zohoapis.sa' },
 };
@@ -46,7 +46,6 @@ const DEFAULT_LOCATION: ZohoLocation = 'us';
 export class Api extends OAuth2Requester {
     public URLs: Record<string, string | ((id: string) => string)>;
     public location: ZohoLocation;
-    public accountsServer: string | null;
 
     private static readonly CONTACTS_DEFAULT_FIELDS = 'id,First_Name,Last_Name,Email,Phone,Mobile,Account_Name,Company,Owner,Lead_Source,Created_Time,Modified_Time';
     private static readonly LEADS_DEFAULT_FIELDS = 'id,First_Name,Last_Name,Email,Phone,Mobile,Company,Industry,Lead_Source,Lead_Status,Owner,Created_Time,Modified_Time,Converted__s,Converted_Date_Time';
@@ -55,7 +54,6 @@ export class Api extends OAuth2Requester {
     constructor(params: ZohoConfig) {
         super(params);
 
-        this.accountsServer = get(params, 'accountsServer', null) as string | null;
         this.location = get(params, 'location', DEFAULT_LOCATION) as ZohoLocation;
         if (!LOCATION_CONFIG[this.location]) {
             this.location = DEFAULT_LOCATION;
@@ -63,9 +61,7 @@ export class Api extends OAuth2Requester {
         const locationConfig = LOCATION_CONFIG[this.location];
 
         this.baseUrl = `${locationConfig.api}/crm/v8`;
-        this.tokenUri = this.accountsServer
-            ? `${this.accountsServer}/oauth/v2/token`
-            : `${locationConfig.accounts}/oauth/v2/token`;
+        this.tokenUri = `${locationConfig.accounts}/oauth/v2/token`;
         this.authorizationUri = encodeURI(
             `${locationConfig.accounts}/oauth/v2/auth?scope=${this.scope}&client_id=${this.client_id}&redirect_uri=${this.redirect_uri}&response_type=code&access_type=offline`
         );
@@ -97,10 +93,6 @@ export class Api extends OAuth2Requester {
         return this.authorizationUri;
     }
 
-    /**
-     * Sets the datacenter location and updates URLs accordingly.
-     * Note: tokenUri is only updated if accountsServer is not set.
-     */
     setLocation(location: ZohoLocation): void {
         if (!LOCATION_CONFIG[location]) {
             throw new Error(
@@ -111,21 +103,10 @@ export class Api extends OAuth2Requester {
         this.location = location;
         const locationConfig = LOCATION_CONFIG[location];
         this.baseUrl = `${locationConfig.api}/crm/v8`;
-        if (!this.accountsServer) {
-            this.tokenUri = `${locationConfig.accounts}/oauth/v2/token`;
-        }
+        this.tokenUri = `${locationConfig.accounts}/oauth/v2/token`;
         this.authorizationUri = encodeURI(
             `${locationConfig.accounts}/oauth/v2/auth?scope=${this.scope}&client_id=${this.client_id}&redirect_uri=${this.redirect_uri}&response_type=code&access_type=offline`
         );
-    }
-
-    /**
-     * Sets the accounts server URL for token operations.
-     * Call this when accounts-server is provided in OAuth callback.
-     */
-    setAccountsServer(accountsServer: string): void {
-        this.accountsServer = accountsServer;
-        this.tokenUri = `${accountsServer}/oauth/v2/token`;
     }
 
     async getTokenFromCode(code: string): Promise<TokenResponse> {

--- a/packages/v1-ready/zoho-crm/src/definition.ts
+++ b/packages/v1-ready/zoho-crm/src/definition.ts
@@ -15,7 +15,6 @@ export const Definition = {
         getToken: async function(api: Api, params: any): Promise<void> {
             const code = get(params, 'code');
             const location = get(params, 'location', null) as ZohoLocation | null;
-            console.log('[zoho]: Received params in getToken:', JSON.stringify(params));
 
             if (location) {
                 api.setLocation(location);

--- a/packages/v1-ready/zoho-crm/src/definition.ts
+++ b/packages/v1-ready/zoho-crm/src/definition.ts
@@ -15,6 +15,7 @@ export const Definition = {
         getToken: async function(api: Api, params: any): Promise<void> {
             const code = get(params, 'code');
             const location = get(params, 'location', null) as ZohoLocation | null;
+            console.log('[zoho]: Received params in getToken:', JSON.stringify(params));
 
             if (location) {
                 api.setLocation(location);

--- a/packages/v1-ready/zoho-crm/src/definition.ts
+++ b/packages/v1-ready/zoho-crm/src/definition.ts
@@ -15,20 +15,16 @@ export const Definition = {
         getToken: async function(api: Api, params: any): Promise<void> {
             const code = get(params, 'code');
             const location = get(params, 'location', null) as ZohoLocation | null;
-            const accountsServer = get(params, 'accounts-server', null) as string | null;
 
             if (location) {
                 api.setLocation(location);
-            }
-            if (accountsServer) {
-                api.setAccountsServer(accountsServer);
             }
 
             await api.getTokenFromCode(code);
         },
         apiPropertiesToPersist: {
             credential: ['access_token', 'refresh_token'],
-            entity: ['location', 'accountsServer'],
+            entity: ['location'],
         },
         getCredentialDetails: async function (api: Api, userId: string): Promise<any> {
             const response = await api.listUsers({type: 'CurrentUser'});
@@ -46,7 +42,6 @@ export const Definition = {
                 details: {
                     name: currentUser.email,
                     location: api.location,
-                    accountsServer: api.accountsServer,
                 },
             };
         },

--- a/packages/v1-ready/zoho-crm/src/types.ts
+++ b/packages/v1-ready/zoho-crm/src/types.ts
@@ -12,7 +12,6 @@ export interface ZohoConfig {
     access_token?: string | null;
     refresh_token?: string | null;
     location?: ZohoLocation;
-    accountsServer?: string | null;
 }
 
 export interface PaginationInfo {


### PR DESCRIPTION
## Summary
- Remove the `accountsServer` property from the Zoho CRM API module — tokenUri is now always derived from the datacenter `location` config
- Remove `setAccountsServer()` method and related extraction of `accounts-server` from OAuth callback params
- Clean up `apiPropertiesToPersist` and `getEntityDetails` to no longer reference `accountsServer`

## Test plan
- [x] `npx tsc --noEmit` passes with no type errors
- [x] Grep confirms zero remaining references to `accountsServer` / `accounts-server` / `setAccountsServer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-zoho-crm@1.1.0-canary.73.f16314c.0
  # or 
  yarn add @friggframework/api-module-zoho-crm@1.1.0-canary.73.f16314c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-zoho-crm@2.0.0-next.6`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-zoho-crm`
    - fix(zoho-crm): remove accountsServer in favor of location-based token URLs [#73](https://github.com/friggframework/api-module-library/pull/73) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - refactor(api-modules): rename identifiers.user to identifiers.userId [#70](https://github.com/friggframework/api-module-library/pull/70) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
