### PR TITLE
fix(zoho-crm): add CRM base URL and org endpoint for correct contact links

### DIFF
--- a/packages/v1-ready/zoho-crm/src/api.ts
+++ b/packages/v1-ready/zoho-crm/src/api.ts
@@ -24,21 +24,22 @@ import {
     NotificationDetailsResponse,
     ZohoCallData,
     CallsResponse,
+    OrgResponse,
 } from './types';
 
 /**
  * Zoho datacenter URL configuration
  * @see https://www.zoho.com/crm/developer/docs/api/v8/multi-dc.html
  */
-const LOCATION_CONFIG: Record<ZohoLocation, { accounts: string; api: string }> = {
-    us: { accounts: 'https://accounts.zoho.com', api: 'https://www.zohoapis.com' },
-    eu: { accounts: 'https://accounts.zoho.eu', api: 'https://www.zohoapis.eu' },
-    in: { accounts: 'https://accounts.zoho.in', api: 'https://www.zohoapis.in' },
-    au: { accounts: 'https://accounts.zoho.com.au', api: 'https://www.zohoapis.com.au' },
-    cn: { accounts: 'https://accounts.zoho.com.cn', api: 'https://www.zohoapis.com.cn' },
-    ca: { accounts: 'https://accounts.zohocloud.ca', api: 'https://www.zohoapis.ca' },
-    jp: { accounts: 'https://accounts.zoho.jp', api: 'https://www.zohoapis.jp' },
-    sa: { accounts: 'https://accounts.zoho.sa', api: 'https://www.zohoapis.sa' },
+const LOCATION_CONFIG: Record<ZohoLocation, { accounts: string; api: string; crm: string }> = {
+    us: { accounts: 'https://accounts.zoho.com', api: 'https://www.zohoapis.com', crm: 'https://crm.zoho.com' },
+    eu: { accounts: 'https://accounts.zoho.eu', api: 'https://www.zohoapis.eu', crm: 'https://crm.zoho.eu' },
+    in: { accounts: 'https://accounts.zoho.in', api: 'https://www.zohoapis.in', crm: 'https://crm.zoho.in' },
+    au: { accounts: 'https://accounts.zoho.com.au', api: 'https://www.zohoapis.com.au', crm: 'https://crm.zoho.com.au' },
+    cn: { accounts: 'https://accounts.zoho.com.cn', api: 'https://www.zohoapis.com.cn', crm: 'https://crm.zoho.com.cn' },
+    ca: { accounts: 'https://accounts.zohocloud.ca', api: 'https://www.zohoapis.ca', crm: 'https://crm.zohocloud.ca' },
+    jp: { accounts: 'https://accounts.zoho.jp', api: 'https://www.zohoapis.jp', crm: 'https://crm.zoho.jp' },
+    sa: { accounts: 'https://accounts.zoho.sa', api: 'https://www.zohoapis.sa', crm: 'https://crm.zoho.sa' },
 };
 
 const DEFAULT_LOCATION: ZohoLocation = 'us';
@@ -95,11 +96,20 @@ export class Api extends OAuth2Requester {
             calls: '/Calls',
             call: (callId: string) => `/Calls/${callId}`,
             notificationsWatch: '/actions/watch',
+            org: '/org',
         };
     }
 
     getAuthUri(): string {
         return this.authorizationUri;
+    }
+
+    getCrmBaseUrl(): string {
+        return LOCATION_CONFIG[this.location].crm;
+    }
+
+    async getOrg(): Promise<OrgResponse> {
+        return this._get({ url: this.baseUrl + this.URLs.org });
     }
 
     setLocation(location: ZohoLocation): void {

--- a/packages/v1-ready/zoho-crm/src/types.ts
+++ b/packages/v1-ready/zoho-crm/src/types.ts
@@ -415,6 +415,19 @@ export interface ZohoCallData {
     [key: string]: any;
 }
 
+export interface ZohoOrg {
+    id: string;
+    company_name: string;
+    domain_name: string;
+    time_zone: string;
+    currency: string;
+    [key: string]: any;
+}
+
+export interface OrgResponse {
+    org: ZohoOrg[];
+}
+
 /**
  * Response from Calls module operations
  */


### PR DESCRIPTION
## Summary

- Add datacenter-specific CRM URLs to `LOCATION_CONFIG` for all 8 Zoho datacenters
- Add `getCrmBaseUrl()` getter to expose the correct CRM front-end URL per datacenter
- Add `getOrg()` method calling the `/org` endpoint to retrieve org details (including `domain_name`)
- Add `ZohoOrg` and `OrgResponse` TypeScript types

## Motivation

The `sourceUrl` generated for Zoho CRM contacts/accounts was hardcoded to `https://crm.zoho.com/crm/org/...`, which broke for non-US datacenters and always used a placeholder org segment. Callers now have the primitives to build accurate, datacenter-aware contact URLs with the real org domain name.

## Test plan

- [ ] Canary release installs successfully in downstream integration
- [ ] `getCrmBaseUrl()` returns correct URL per datacenter location
- [ ] `getOrg()` returns org details including `domain_name`
- [ ] Contact `sourceUrl` links correctly to the Zoho CRM contact page
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-zoho-crm@1.1.0-canary.77.56600ee.0
  # or 
  yarn add @friggframework/api-module-zoho-crm@1.1.0-canary.77.56600ee.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-zoho-crm@2.0.0-next.9`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat(api): prevent calling setTokens on Zoho API error [#76](https://github.com/friggframework/api-module-library/pull/76) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-zoho-crm`
    - fix(zoho-crm): add CRM base URL and org endpoint for correct contact links [#77](https://github.com/friggframework/api-module-library/pull/77) ([@roboli](https://github.com/roboli))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
