### PR TITLE
Update frigg core version to 2.0.0-next.75 for frontify module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15951,7 +15951,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -18066,6 +18065,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -18081,6 +18081,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -18393,7 +18394,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -19876,7 +19876,6 @@
       "version": "3.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -22116,7 +22115,6 @@
     "node_modules/@types/node": {
       "version": "22.3.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.18.2"
       }
@@ -22502,7 +22500,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -23488,7 +23485,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -24629,7 +24625,6 @@
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -26348,7 +26343,6 @@
       "version": "8.57.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -27195,8 +27189,7 @@
     "node_modules/fp-ts": {
       "version": "2.16.9",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -27767,7 +27760,6 @@
     "node_modules/graphql": {
       "version": "15.10.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -29197,7 +29189,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -29466,7 +29457,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -31065,7 +31055,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -33466,7 +33455,6 @@
       "integrity": "sha512-barpwhq8noc30U0d5j2bSp9x/HDL33TCYsP2fl6FvpssbL64PwLOSBqIdZ9ATxVxAE/xAc/s+z72cYDkaYouPA==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -36551,7 +36539,6 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -36783,9 +36770,8 @@
     },
     "node_modules/typescript": {
       "version": "5.5.4",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -41574,6 +41560,7 @@
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -41752,6 +41739,7 @@
       "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.2.0",
@@ -41779,6 +41767,7 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -41797,7 +41786,8 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
       "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "packages/v1-ready/frigg-scale-test/node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -41844,6 +41834,7 @@
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -41856,36 +41847,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/v1-ready/frigg-scale-test/node_modules/babel-plugin-jest-hoist": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-      "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/babel__core": "^7.20.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "packages/v1-ready/frigg-scale-test/node_modules/babel-preset-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-      "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "babel-plugin-jest-hoist": "30.2.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "packages/v1-ready/frigg-scale-test/node_modules/camelcase": {
@@ -42703,6 +42664,7 @@
       "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -42728,6 +42690,7 @@
       "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -42881,6 +42844,7 @@
       "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -43427,6 +43391,7 @@
       "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -43451,6 +43416,7 @@
         }
       ],
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -43461,6 +43427,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -43740,6 +43707,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -43847,6 +43815,7 @@
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -43887,7 +43856,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@friggframework/core": "^2.0.0-next.16"
+        "@friggframework/core": "^2.0.0-next.75"
       },
       "devDependencies": {
         "dotenv": "^16.3.1",
@@ -43898,14 +43867,20 @@
       }
     },
     "packages/v1-ready/frontify/node_modules/@friggframework/core": {
-      "version": "2.0.0-next.23",
-      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.23.tgz",
-      "integrity": "sha512-TtYVAB9gJ7voT7t69XqEEPeTSZIeiDphLuOFuAQHw4359bY63uYq+PX3QWxEX4EmTQeUTRL+EJ2TuABu4Ic9wg==",
+      "version": "2.0.0-next.75",
+      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.75.tgz",
+      "integrity": "sha512-y053DvLZvCJAEzw5t3FchiMtMAVZepSZp8vMaGrlUlFeRsRp8MAP6PqTwzzSWWpPpSauT1uV9qMMAahRnhfYhA==",
+      "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.588.0",
+        "@aws-sdk/client-kms": "^3.588.0",
+        "@aws-sdk/client-lambda": "^3.714.0",
+        "@aws-sdk/client-sqs": "^3.588.0",
         "@hapi/boom": "^10.0.1",
-        "aws-sdk": "^2.1200.0",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
+        "bson": "^4.7.2",
+        "chalk": "^4.1.2",
         "common-tags": "^1.8.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -43915,10 +43890,21 @@
         "fs-extra": "^11.2.0",
         "lodash": "4.17.21",
         "lodash.get": "^4.4.2",
-        "mongoose": "6.11.6",
         "node-fetch": "^2.6.7",
         "serverless-http": "^2.7.0",
         "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@prisma/client": "^6.16.3",
+        "prisma": "^6.16.3"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "packages/v1-ready/frontify/node_modules/@jest/console": {
@@ -44853,49 +44839,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "packages/v1-ready/frontify/node_modules/mongodb": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
-      "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
-      "dependencies": {
-        "bson": "^4.7.2",
-        "mongodb-connection-string-url": "^2.5.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=12.9.0"
-      },
-      "optionalDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "saslprep": "^1.0.3"
-      }
-    },
-    "packages/v1-ready/frontify/node_modules/mongoose": {
-      "version": "6.11.6",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.6.tgz",
-      "integrity": "sha512-CuVbeJrEbnxkPUNNFvXJhjVyqa5Ip7lkz6EJX6g7Lb3aFMTJ+LHOlUrncxzC3r20dqasaVIiwcA6Y5qC8PWQ7w==",
-      "dependencies": {
-        "bson": "^4.7.2",
-        "kareem": "2.5.1",
-        "mongodb": "4.16.0",
-        "mpath": "0.9.0",
-        "mquery": "4.0.3",
-        "ms": "2.1.3",
-        "sift": "16.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "packages/v1-ready/frontify/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "packages/v1-ready/frontify/node_modules/prettier": {
       "version": "3.5.3",

--- a/packages/v1-ready/frontify/package.json
+++ b/packages/v1-ready/frontify/package.json
@@ -18,7 +18,7 @@
     "sinon": "^16.0.0"
   },
   "dependencies": {
-    "@friggframework/core": "^2.0.0-next.16"
+    "@friggframework/core": "^2.0.0-next.75"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary\n- Update `@friggframework/core` dependency from `^2.0.0-next.16` to `^2.0.0-next.75` in the frontify api-module\n\n## Test plan\n- [ ] Verify frontify module installs correctly with the updated core version\n- [ ] Run existing frontify module tests\n\nhttps://claude.ai/code/session_011UivYC7KL9ji24EWY2ez1L
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@1.3.1-canary.79.a277d81.0
  # or 
  yarn add @friggframework/api-module-frontify@1.3.1-canary.79.a277d81.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-frontify@2.0.0-next.18`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Claude ([@claude](https://github.com/claude)), for all your work!
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-frontify`
    - Update frigg core version to 2.0.0-next.75 for frontify module [#79](https://github.com/friggframework/api-module-library/pull/79) ([@claude](https://github.com/claude) [@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - remove refresh for Attio module [#74](https://github.com/friggframework/api-module-library/pull/74) ([@MichaelRyanWebber](https://github.com/MichaelRyanWebber))
  
  #### Authors: 3
  
  - [@MichaelRyanWebber](https://github.com/MichaelRyanWebber)
  - Claude ([@claude](https://github.com/claude))
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
