### PR TITLE
fix(frontify): handle GraphQL auth errors for token refresh

### DIFF
--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -118,6 +118,39 @@ class Api extends OAuth2Requester {
         };
     }
 
+    static GRAPHQL_AUTH_ERROR_PATTERN = 'not set in identity';
+
+    /**
+     * Override _post to handle Frontify's GraphQL auth errors.
+     * Frontify returns HTTP 200 with GraphQL errors for expired tokens,
+     * bypassing the framework's HTTP 401-based automatic token refresh.
+     * The stringify parameter distinguishes GraphQL requests (true) from
+     * token refresh requests (false), preventing infinite retry loops.
+     */
+    async _post(options, stringify = true) {
+        const response = await super._post(options, stringify);
+
+        if (!stringify || !response?.errors) return response;
+
+        const hasAuthError = response.errors.some(
+            (e) => e.message?.includes(Api.GRAPHQL_AUTH_ERROR_PATTERN),
+        );
+
+        if (hasAuthError && this.isRefreshable && this.refreshCount === 0) {
+            this.refreshCount++;
+            try {
+                await this.refreshAuth();
+            } catch {
+                return response;
+            }
+            if (this.access_token) {
+                return super._post(options, stringify);
+            }
+        }
+
+        return response;
+    }
+
     /**
      * Asserts that a GraphQL response is valid
      * @private

--- a/packages/v1-ready/frontify/api.test.js
+++ b/packages/v1-ready/frontify/api.test.js
@@ -2359,4 +2359,112 @@ describe(`${Config.label} API Tests`, () => {
             });
         });
     });
+
+    describe('GraphQL auth error token refresh', () => {
+        afterEach(() => {
+            nock.cleanAll();
+        });
+
+        it('should refresh token and retry on auth error', async () => {
+            const api = new Api({
+                domain: 'domain-mine',
+                access_token: 'expired_token',
+                refresh_token: 'valid_refresh',
+                client_id: 'test_client',
+            });
+
+            // First call returns auth error
+            const authErrorScope = nock(baseUrl)
+                .post('')
+                .reply(200, {
+                    errors: [{ message: 'UserId not set in identity.' }],
+                    data: null,
+                });
+
+            // Refresh returns new token
+            const refreshScope = nock('https://domain-mine')
+                .post('/api/oauth/refresh')
+                .reply(200, {
+                    access_token: 'new_token',
+                    refresh_token: 'new_refresh',
+                    expires_in: 3600,
+                });
+
+            // Retry succeeds
+            const retryScope = nock(baseUrl)
+                .post('')
+                .reply(200, {
+                    data: { brands: [{ id: '1', name: 'Brand' }] },
+                });
+
+            const result = await api.listBrands();
+
+            expect(result).toEqual({ brands: [{ id: '1', name: 'Brand' }] });
+            expect(authErrorScope.isDone()).toBe(true);
+            expect(refreshScope.isDone()).toBe(true);
+            expect(retryScope.isDone()).toBe(true);
+        });
+
+        it('should not retry on non-auth GraphQL errors', async () => {
+            const api = new Api({
+                domain: 'domain-mine',
+                access_token: 'valid_token',
+                refresh_token: 'valid_refresh',
+            });
+
+            const errorScope = nock(baseUrl)
+                .post('')
+                .reply(200, {
+                    errors: [{ message: 'Some other GraphQL error' }],
+                    data: null,
+                });
+
+            await expect(api.listBrands()).rejects.toThrow('Some other GraphQL error');
+            expect(errorScope.isDone()).toBe(true);
+        });
+
+        it('should throw original error when refresh fails', async () => {
+            const api = new Api({
+                domain: 'domain-mine',
+                access_token: 'expired_token',
+                refresh_token: 'bad_refresh',
+                client_id: 'test_client',
+            });
+
+            const authErrorScope = nock(baseUrl)
+                .post('')
+                .reply(200, {
+                    errors: [{ message: 'UserId not set in identity.' }],
+                    data: null,
+                });
+
+            // Refresh fails
+            const refreshScope = nock('https://domain-mine')
+                .post('/api/oauth/refresh')
+                .reply(401, { error: 'invalid_grant' });
+
+            await expect(api.listBrands()).rejects.toThrow('UserId not set in identity.');
+            expect(authErrorScope.isDone()).toBe(true);
+            expect(refreshScope.isDone()).toBe(true);
+        });
+
+        it('should not intercept token refresh requests', async () => {
+            const api = new Api({
+                domain: 'domain-mine',
+                access_token: 'token',
+                refresh_token: 'refresh',
+                client_id: 'test_client',
+            });
+
+            // Token refresh endpoint returns an error (stringify=false path)
+            const refreshScope = nock('https://domain-mine')
+                .post('/api/oauth/refresh')
+                .reply(401, { error: 'invalid_grant' });
+
+            await expect(
+                api.refreshAccessToken({ refresh_token: 'refresh' })
+            ).rejects.toBeTruthy();
+            expect(refreshScope.isDone()).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Problem

Frontify's GraphQL API returns **HTTP 200** with GraphQL error objects for expired tokens:
```json
{ "errors": [{ "message": "UserId not set in identity." }] }
```

The framework's automatic token refresh only triggers on **HTTP 401** responses (`Requester._request`), so expired Frontify tokens are never refreshed. This causes persistent auth failures in production (AWS Lambda) where tokens expire between invocations.

## Solution

Override `_post` in the Frontify API class to:
1. **Detect** GraphQL auth errors (`not set in identity`) in HTTP 200 responses
2. **Refresh** the token via `refreshAuth()`
3. **Retry** the original request with the new access token

### Guard rails
- Only intercepts GraphQL requests (`stringify=true`), not token refresh requests (`stringify=false`) — prevents infinite retry loops
- Uses `refreshCount` to retry at most once (same pattern as `Requester._request`)
- Checks `this.access_token` after refresh instead of relying on `refreshAuth()` return value (compatible with older `@friggframework/core` versions)

## Tests

4 new tests:
- Auth error → refresh → retry succeeds
- Non-auth GraphQL errors are not retried
- Refresh failure → original auth error propagates
- Token refresh requests (`stringify=false`) are not intercepted
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@1.3.1-canary.80.1b568f8.0
  # or 
  yarn add @friggframework/api-module-frontify@1.3.1-canary.80.1b568f8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-frontify@2.0.0-next.19`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-frontify`
    - fix(frontify): handle GraphQL auth errors for token refresh [#80](https://github.com/friggframework/api-module-library/pull/80) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Update frigg core version to 2.0.0-next.75 for frontify module [#79](https://github.com/friggframework/api-module-library/pull/79) ([@claude](https://github.com/claude) [@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 2
  
  - Claude ([@claude](https://github.com/claude))
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
