### PR TITLE
fix(frontify): set statusCode 401 on GraphQL auth errors

### DIFF
--- a/packages/v1-ready/frontify/api.js
+++ b/packages/v1-ready/frontify/api.js
@@ -160,7 +160,11 @@ class Api extends OAuth2Requester {
     assertResponse(response) {
         if (response.errors) {
             const {errors} = response;
-            throw new Error(errors[0].message);
+            const error = new Error(errors[0].message);
+            if (errors[0].message?.includes(Api.GRAPHQL_AUTH_ERROR_PATTERN)) {
+                error.statusCode = 401;
+            }
+            throw error;
         }
     }
 

--- a/packages/v1-ready/frontify/api.test.js
+++ b/packages/v1-ready/frontify/api.test.js
@@ -2467,4 +2467,44 @@ describe(`${Config.label} API Tests`, () => {
             expect(refreshScope.isDone()).toBe(true);
         });
     });
+
+    describe('assertResponse auth error statusCode', () => {
+        it('should set statusCode 401 on auth identity errors', async () => {
+            const api = new Api({ domain: 'domain-mine' });
+
+            nock(baseUrl)
+                .post('')
+                .reply(200, {
+                    errors: [{ message: 'UserId not set in identity.' }],
+                    data: null,
+                });
+
+            try {
+                await api.listBrands();
+                fail('Expected error to be thrown');
+            } catch (error) {
+                expect(error.message).toBe('UserId not set in identity.');
+                expect(error.statusCode).toBe(401);
+            }
+        });
+
+        it('should not set statusCode on non-auth GraphQL errors', async () => {
+            const api = new Api({ domain: 'domain-mine' });
+
+            nock(baseUrl)
+                .post('')
+                .reply(200, {
+                    errors: [{ message: 'Some other GraphQL error' }],
+                    data: null,
+                });
+
+            try {
+                await api.listBrands();
+                fail('Expected error to be thrown');
+            } catch (error) {
+                expect(error.message).toBe('Some other GraphQL error');
+                expect(error.statusCode).toBeUndefined();
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Problem

`assertResponse` throws plain `Error` objects for all GraphQL errors — no `statusCode` property. Consumers that check `error.statusCode === 401` to trigger re-authentication (e.g., `GenerateFormMetadataUseCase`) can never match, so auth failures surface as generic 500 errors instead of prompting users to re-authenticate.

This means when Frontify returns `"UserId not set in identity."` (expired token) and token refresh fails (e.g., revoked refresh token), the user sees a broken form instead of being redirected to re-auth.

## Solution

Detect the Frontify identity error pattern in `assertResponse` and set `statusCode = 401` on the thrown error. Non-auth GraphQL errors are unaffected.

```javascript
// Before
throw new Error(errors[0].message);  // no statusCode

// After  
const error = new Error(errors[0].message);
if (errors[0].message?.includes('not set in identity')) {
    error.statusCode = 401;
}
throw error;
```

## Related

- PR #80: Adds `_post` override for automatic token refresh on GraphQL auth errors
- This PR ensures that when refresh fails, the error is properly tagged as 401 so consumers can trigger re-authentication

## Tests

- Auth identity error → `statusCode = 401`
- Non-auth GraphQL error → `statusCode` undefined (unchanged behavior)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-frontify@1.3.1-canary.82.0a63b1f.0
  # or 
  yarn add @friggframework/api-module-frontify@1.3.1-canary.82.0a63b1f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-frontify@2.0.0-next.20`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-frontify`
    - fix(frontify): set statusCode 401 on GraphQL auth errors [#82](https://github.com/friggframework/api-module-library/pull/82) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - Update @friggframework/core to 2.0.0-next.75 in Asana module [#81](https://github.com/friggframework/api-module-library/pull/81) ([@claude](https://github.com/claude) [@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 2
  
  - Claude ([@claude](https://github.com/claude))
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
