### PR TITLE
feat(pipedrive): add findUsers method for /v1/users/find endpoint

### DIFF
--- a/packages/v1-ready/pipedrive/src/api.ts
+++ b/packages/v1-ready/pipedrive/src/api.ts
@@ -29,6 +29,7 @@ export class Api extends OAuth2Requester {
     activityById: (activityId: string | number) => string;
     getUser: string;
     users: string;
+    usersFind: string;
     deals: string;
     persons: string;
     personById: (personId: string | number) => string;
@@ -57,6 +58,7 @@ export class Api extends OAuth2Requester {
         `/v2/activities/${activityId}`,
       getUser: "/v1/users/me",
       users: "/v1/users",
+      usersFind: "/v1/users/find",
       deals: "/v2/deals",
       persons: "/v2/persons",
       personById: (personId: string | number) => `/v2/persons/${personId}`,
@@ -221,6 +223,14 @@ export class Api extends OAuth2Requester {
   async listUsers(): Promise<PipedriveResponse> {
     const options: RequestOptions = {
       url: this.baseUrl + this.URLs.users,
+    };
+    return this._get(options);
+  }
+
+  async findUsers(params: { term: string; search_by_email?: 0 | 1 }): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.usersFind,
+      query: params,
     };
     return this._get(options);
   }


### PR DESCRIPTION
### Summary

- Add `findUsers()` method to the Pipedrive API module to search users by name or email via `/v1/users/find`
- Needed for resolving Quo users to Pipedrive users when setting activity/note ownership (`owner_id`/`user_id`)

### Changes

**Pipedrive API Module** (`packages/v1-ready/pipedrive/src/api.ts`):
- Added `usersFind: "/v1/users/find"` to `this.URLs`
- Added `findUsers(params: { term: string; search_by_email?: 0 | 1 }): Promise<PipedriveResponse>` method

### Context

When the Quo integration creates call activities or notes in Pipedrive, they are attributed to the OAuth token holder instead of the actual Quo user who made/answered the call. To fix this, we need to resolve Quo users to Pipedrive users by searching for them by email (primary) or name (fallback) using the `/v1/users/find` endpoint, then set `owner_id` on activities and `user_id` on notes.

### Configuration

This endpoint requires the `users:read` OAuth scope. Existing Pipedrive OAuth apps need this scope added in the Developer Hub, and existing connections need re-authorization.

### Related Issues

- ClickUp: https://app.clickup.com/t/86age87f5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-pipedrive@2.1.0-canary.83.fedcd2f.0
  # or 
  yarn add @friggframework/api-module-pipedrive@2.1.0-canary.83.fedcd2f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-pipedrive@2.1.0-next.6`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-pipedrive`
    - feat(pipedrive): add findUsers method for /v1/users/find endpoint [#83](https://github.com/friggframework/api-module-library/pull/83) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix(frontify): set statusCode 401 on GraphQL auth errors [#82](https://github.com/friggframework/api-module-library/pull/82) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
