### PR TITLE
fix(salesforce): fix OAuth flow bugs and add unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9571,65 +9571,6 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.631.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
-      "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.631.0",
-        "@aws-sdk/core": "3.629.0",
-        "@aws-sdk/credential-provider-node": "3.631.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.631.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.631.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.3.2",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.14",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.1.12",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.14",
-        "@smithy/util-defaults-mode-node": "^3.0.14",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@aws-sdk/core": {
       "version": "3.629.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
@@ -14705,6 +14646,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -17028,7 +16970,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -17044,7 +16985,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -17386,6 +17326,7 @@
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -18987,6 +18928,7 @@
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -21548,6 +21490,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
       "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.18.2"
       }
@@ -21994,6 +21937,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -23154,6 +23098,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -24479,6 +24424,7 @@
       "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -26059,29 +26005,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -26422,6 +26345,7 @@
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -27422,7 +27346,8 @@
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz",
       "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -28060,6 +27985,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.9.0.tgz",
       "integrity": "sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -29584,6 +29510,7 @@
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -29894,6 +29821,7 @@
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -31538,6 +31466,7 @@
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -34153,6 +34082,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -37695,6 +37625,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -37961,6 +37892,7 @@
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -45957,7 +45889,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -46149,7 +46080,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.3.0",
@@ -46177,7 +46107,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -46197,8 +46126,7 @@
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "packages/v1-ready/frigg-scale-test/node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -46243,30 +46171,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "packages/v1-ready/frigg-scale-test/node_modules/babel-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/transform": "30.3.0",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.3.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
-      }
-    },
     "packages/v1-ready/frigg-scale-test/node_modules/babel-plugin-istanbul": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
@@ -46274,7 +46178,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -46296,7 +46199,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/babel__core": "^7.20.5"
       },
@@ -46311,7 +46213,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "30.3.0",
         "babel-preset-current-node-syntax": "^1.2.0"
@@ -47136,7 +47037,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -47163,7 +47063,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -47182,7 +47081,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -47343,7 +47241,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -47926,7 +47823,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -47952,7 +47848,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -47964,7 +47859,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -48266,7 +48160,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -48380,7 +48273,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -55628,7 +55520,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@friggframework/core": "^1.1.6",
+        "@friggframework/core": "2.0.0-next.79",
         "jsforce": "^3.8.1"
       },
       "devDependencies": {
@@ -55641,17 +55533,70 @@
         "prettier": "^2.7.1"
       }
     },
+    "packages/v1-ready/salesforce/node_modules/@friggframework/core": {
+      "version": "2.0.0-next.79",
+      "resolved": "https://registry.npmjs.org/@friggframework/core/-/core-2.0.0-next.79.tgz",
+      "integrity": "sha512-tw2Hh33PHR0XxcGjgUYt2ssdgmmN8cI2Bz8KTiSI2affWJQZuC4Np4mPG97hhDWmKWHEOYl0KciaqYlt22HaOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.588.0",
+        "@aws-sdk/client-kms": "^3.588.0",
+        "@aws-sdk/client-lambda": "^3.714.0",
+        "@aws-sdk/client-sqs": "^3.588.0",
+        "@hapi/boom": "^10.0.1",
+        "bcryptjs": "^2.4.3",
+        "body-parser": "^1.20.2",
+        "bson": "^4.7.2",
+        "chalk": "^4.1.2",
+        "common-tags": "^1.8.2",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
+        "express": "^4.19.2",
+        "express-async-handler": "^1.2.0",
+        "form-data": "^4.0.0",
+        "fs-extra": "^11.2.0",
+        "lodash": "4.17.21",
+        "lodash.get": "^4.4.2",
+        "node-fetch": "^2.6.7",
+        "serverless-http": "^2.7.0",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@prisma/client": "^6.16.3",
+        "prisma": "^6.16.3"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
     "packages/v1-ready/salesforce/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "dev": true,
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "packages/v1-ready/salesforce/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/v1-ready/stripe": {

--- a/packages/v1-ready/salesforce/api.js
+++ b/packages/v1-ready/salesforce/api.js
@@ -37,19 +37,15 @@ class Api extends OAuth2Requester {
         });
     }
 
-    async getAuthorizationUri() {
-        try {
-            return this.oauth2.getAuthorizationUrl({});
-        } catch (error) {
-            return error;
-        }
+    getAuthorizationUri() {
+        return this.oauth2.getAuthorizationUrl({ scope: 'full refresh_token' });
     }
 
     resetToSandbox() {
         this.oauth2 = new jsforce.OAuth2({
             clientId: this.client_id,
             clientSecret: this.client_secret,
-            redirectUri: this.redirectUri,
+            redirectUri: this.redirect_uri,
             loginUrl: 'https://test.salesforce.com',
         });
 
@@ -66,9 +62,9 @@ class Api extends OAuth2Requester {
         try {
             await this.conn.authorize(code);
         } catch (e) {
-            console.log('Error authing with the code. Trying to auth sandbox.');
+            console.log('Error authing with the code. Trying to auth sandbox.', e?.message || e);
             throw new Error(
-                `Error Authing with Code, try Sandbox. ${JSON.stringify(e)}`
+                `Error Authing with Code, try Sandbox. ${e?.message || JSON.stringify(e)}`
             );
         }
         const OAuthDetails = {

--- a/packages/v1-ready/salesforce/api.js
+++ b/packages/v1-ready/salesforce/api.js
@@ -38,7 +38,7 @@ class Api extends OAuth2Requester {
     }
 
     getAuthorizationUri() {
-        return this.oauth2.getAuthorizationUrl({ scope: 'full refresh_token' });
+        return this.oauth2.getAuthorizationUrl({ scope: this.scope });
     }
 
     resetToSandbox() {

--- a/packages/v1-ready/salesforce/definition.js
+++ b/packages/v1-ready/salesforce/definition.js
@@ -11,14 +11,14 @@ const Definition = {
     moduleName: config.name,
     modelName: 'Salesforce',
     requiredAuthMethods: {
-        getAuthorizationRequirements: async function (params) {
+        getAuthorizationRequirements: function (params) {
             return {
-                url: await this.api.getAuthorizationUri(),
+                url: this.api.getAuthorizationUri(),
                 type: 'oauth2',
             };
         },
         getToken: async function (api, params) {
-            const code = get(params.data, 'code');
+            const code = get(params, 'code');
             let tokenResponse;
             try {
                 tokenResponse = await api.getAccessToken(code);
@@ -48,7 +48,7 @@ const Definition = {
         },
         getCredentialDetails: async function (api, userId) {
             return {
-                identifiers: { instanceUrl: api.instanceUrl, userId },
+                identifiers: { externalId: api.instanceUrl, userId },
                 details: {}
             };
         },

--- a/packages/v1-ready/salesforce/jest.unit.config.js
+++ b/packages/v1-ready/salesforce/jest.unit.config.js
@@ -1,0 +1,8 @@
+/**
+ * Unit test config — no database setup required.
+ * Use for tests that mock all external dependencies (API, jsforce, etc.)
+ * Run with: npm run test:unit
+ */
+module.exports = {
+    testMatch: ['**/test/api.test.js', '**/test/definition.test.js'],
+};

--- a/packages/v1-ready/salesforce/package.json
+++ b/packages/v1-ready/salesforce/package.json
@@ -20,7 +20,7 @@
     "prettier": "^2.7.1"
   },
   "dependencies": {
-    "@friggframework/core": "^1.1.6",
+    "@friggframework/core": "2.0.0-next.79",
     "jsforce": "^3.8.1"
   }
 }

--- a/packages/v1-ready/salesforce/package.json
+++ b/packages/v1-ready/salesforce/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "lint:fix": "prettier --write --loglevel error . && eslint . --fix",
-    "test": "jest"
+    "test": "jest",
+    "test:unit": "jest --config jest.unit.config.js"
   },
   "author": "",
   "license": "MIT",

--- a/packages/v1-ready/salesforce/test/api.test.js
+++ b/packages/v1-ready/salesforce/test/api.test.js
@@ -1,0 +1,121 @@
+jest.mock('jsforce', () => {
+    const mockGetAuthorizationUrl = jest.fn((options) => {
+        const scope = options?.scope ? `&scope=${encodeURIComponent(options.scope)}` : '';
+        return `https://login.salesforce.com/services/oauth2/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%2Fredirect%2Fsalesforce${scope}`;
+    });
+
+    const mockConnection = {
+        on: jest.fn(),
+        accessToken: 'test-access-token',
+        refreshToken: 'test-refresh-token',
+        instanceUrl: 'https://test.salesforce.com',
+    };
+
+    return {
+        OAuth2: jest.fn().mockImplementation((params) => ({
+            getAuthorizationUrl: mockGetAuthorizationUrl,
+            _params: params,
+        })),
+        Connection: jest.fn().mockImplementation(() => mockConnection),
+    };
+});
+
+const { Api } = require('../api');
+
+const baseParams = {
+    client_id: 'test-client-id',
+    client_secret: 'test-client-secret',
+    redirect_uri: 'http://localhost/redirect/salesforce',
+    delegate: { notify: jest.fn(), addDelegate: jest.fn(), delegateTypes: [] },
+};
+
+describe('Salesforce Api', () => {
+    let api;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        api = new Api(baseParams);
+    });
+
+    describe('getAuthorizationUri', () => {
+        it('should be synchronous (not return a Promise)', () => {
+            const result = api.getAuthorizationUri();
+            expect(result).not.toBeInstanceOf(Promise);
+        });
+
+        it('should return a string URL', () => {
+            const result = api.getAuthorizationUri();
+            expect(typeof result).toBe('string');
+            expect(result).toContain('login.salesforce.com');
+        });
+
+        it('should include refresh_token scope', () => {
+            const result = api.getAuthorizationUri();
+            expect(result).toContain('refresh_token');
+        });
+
+        it('should include full scope', () => {
+            const result = api.getAuthorizationUri();
+            expect(result).toContain('full');
+        });
+    });
+
+    describe('resetToSandbox', () => {
+        it('should use redirect_uri (snake_case) not redirectUri (camelCase)', () => {
+            const jsforce = require('jsforce');
+            api.resetToSandbox();
+
+            const sandboxCall = jsforce.OAuth2.mock.calls.find(
+                (call) => call[0].loginUrl === 'https://test.salesforce.com'
+            );
+            expect(sandboxCall).toBeDefined();
+            expect(sandboxCall[0].redirectUri).toBe(baseParams.redirect_uri);
+        });
+
+        it('should set isSandbox to true', () => {
+            api.resetToSandbox();
+            expect(api.isSandbox).toBe(true);
+        });
+
+        it('should use sandbox login URL', () => {
+            const jsforce = require('jsforce');
+            api.resetToSandbox();
+
+            const sandboxCall = jsforce.OAuth2.mock.calls.find(
+                (call) => call[0].loginUrl === 'https://test.salesforce.com'
+            );
+            expect(sandboxCall[0].loginUrl).toBe('https://test.salesforce.com');
+        });
+    });
+
+    describe('constructor', () => {
+        it('should use production login URL when not sandbox', () => {
+            const jsforce = require('jsforce');
+            new Api(baseParams);
+            const firstCall = jsforce.OAuth2.mock.calls[0];
+            expect(firstCall[0].loginUrl).toBe('https://login.salesforce.com');
+        });
+
+        it('should use sandbox login URL when isSandbox is true', () => {
+            const jsforce = require('jsforce');
+            new Api({ ...baseParams, isSandbox: true });
+            const lastCall = jsforce.OAuth2.mock.calls[jsforce.OAuth2.mock.calls.length - 1];
+            expect(lastCall[0].loginUrl).toBe('https://test.salesforce.com');
+        });
+
+        it('should initialize Connection with access and refresh tokens', () => {
+            const jsforce = require('jsforce');
+            const params = {
+                ...baseParams,
+                access_token: 'my-access-token',
+                refresh_token: 'my-refresh-token',
+                instanceUrl: 'https://myorg.salesforce.com',
+            };
+            new Api(params);
+            const lastCall = jsforce.Connection.mock.calls[jsforce.Connection.mock.calls.length - 1];
+            expect(lastCall[0].accessToken).toBe('my-access-token');
+            expect(lastCall[0].refreshToken).toBe('my-refresh-token');
+            expect(lastCall[0].instanceUrl).toBe('https://myorg.salesforce.com');
+        });
+    });
+});

--- a/packages/v1-ready/salesforce/test/definition.test.js
+++ b/packages/v1-ready/salesforce/test/definition.test.js
@@ -1,0 +1,100 @@
+const { Definition } = require('../definition');
+
+describe('Salesforce Definition', () => {
+    const { requiredAuthMethods } = Definition;
+
+    describe('getAuthorizationRequirements', () => {
+        it('should be synchronous (not return a Promise)', () => {
+            const mockApi = {
+                getAuthorizationUri: () => 'https://login.salesforce.com/auth',
+            };
+            const context = { api: mockApi };
+
+            const result = requiredAuthMethods.getAuthorizationRequirements.call(context);
+            expect(result).not.toBeInstanceOf(Promise);
+        });
+
+        it('should return type oauth2 and a url', () => {
+            const mockApi = {
+                getAuthorizationUri: () => 'https://login.salesforce.com/auth?scope=full+refresh_token',
+            };
+            const context = { api: mockApi };
+
+            const result = requiredAuthMethods.getAuthorizationRequirements.call(context);
+            expect(result.type).toBe('oauth2');
+            expect(result.url).toBe('https://login.salesforce.com/auth?scope=full+refresh_token');
+        });
+    });
+
+    describe('getToken', () => {
+        it('should extract code from params directly (not params.data)', async () => {
+            const capturedArgs = {};
+            const mockApi = {
+                getAccessToken: jest.fn().mockImplementation((code) => {
+                    capturedArgs.code = code;
+                    return Promise.resolve('access-token');
+                }),
+            };
+
+            await requiredAuthMethods.getToken(mockApi, { code: 'test-code' });
+            expect(capturedArgs.code).toBe('test-code');
+        });
+
+        it('should throw when code is nested under params.data instead of params', async () => {
+            const mockApi = {
+                getAccessToken: jest.fn().mockResolvedValue('access-token'),
+                resetToSandbox: jest.fn(),
+            };
+
+            // Passing code nested under data — get(params, 'code') throws RequiredPropertyError
+            await expect(
+                requiredAuthMethods.getToken(mockApi, { data: { code: 'test-code' } })
+            ).rejects.toThrow('code');
+        });
+
+        it('should fall back to sandbox and retry on auth failure', async () => {
+            const mockApi = {
+                getAccessToken: jest.fn()
+                    .mockRejectedValueOnce(new Error('Auth failed'))
+                    .mockResolvedValueOnce('access-token'),
+                resetToSandbox: jest.fn(),
+            };
+
+            const result = await requiredAuthMethods.getToken(mockApi, { code: 'test-code' });
+            expect(mockApi.resetToSandbox).toHaveBeenCalledTimes(1);
+            expect(mockApi.getAccessToken).toHaveBeenCalledTimes(2);
+            expect(result).toBe('access-token');
+        });
+    });
+
+    describe('getCredentialDetails', () => {
+        it('should use externalId as the identifier key', async () => {
+            const mockApi = { instanceUrl: 'https://myorg.salesforce.com' };
+
+            const result = await requiredAuthMethods.getCredentialDetails(mockApi, 'user-123');
+            expect(result.identifiers).toHaveProperty('externalId', 'https://myorg.salesforce.com');
+            expect(result.identifiers).not.toHaveProperty('instanceUrl');
+        });
+
+        it('should include userId in identifiers', async () => {
+            const mockApi = { instanceUrl: 'https://myorg.salesforce.com' };
+
+            const result = await requiredAuthMethods.getCredentialDetails(mockApi, 'user-456');
+            expect(result.identifiers.userId).toBe('user-456');
+        });
+    });
+
+    describe('apiPropertiesToPersist', () => {
+        it('should persist refresh_token', () => {
+            expect(requiredAuthMethods.apiPropertiesToPersist.credential).toContain('refresh_token');
+        });
+
+        it('should persist access_token', () => {
+            expect(requiredAuthMethods.apiPropertiesToPersist.credential).toContain('access_token');
+        });
+
+        it('should persist instanceUrl', () => {
+            expect(requiredAuthMethods.apiPropertiesToPersist.credential).toContain('instanceUrl');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Make `getAuthorizationUri` synchronous — jsforce's `getAuthorizationUrl` is not async; the unnecessary `async` caused `getAuthorizationRequirements` to return a Promise instead of a plain object, breaking the auth URL endpoint for all other modules that call it without `await`
- Add `refresh_token` scope to authorization URL so Salesforce returns a refresh token during the OAuth flow
- Fix `resetToSandbox` typo: `this.redirectUri` → `this.redirect_uri` (camelCase property was undefined, breaking sandbox auth fallback)
- Fix `getToken` to read `code` from `params` directly instead of `params.data`
- Fix `getCredentialDetails` to use `externalId` key instead of `instanceUrl` in identifiers, which is required by `upsertCredential`
- Bump `@friggframework/core` to `2.0.0-next.79`

## Tests

- Add `jest.unit.config.js` without `globalSetup` so unit tests run without MongoDB
- Add `test:unit` script
- Add `test/api.test.js` — covers `getAuthorizationUri` (sync, correct scope), `resetToSandbox` (correct property), constructor token initialization
- Add `test/definition.test.js` — covers `getAuthorizationRequirements` (sync), `getToken` (params extraction), `getCredentialDetails` (externalId), `apiPropertiesToPersist`

## Test plan

- [x] `npm run test:unit` passes (20 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-salesforce@1.0.3-canary.84.ccad42b.0
  # or 
  yarn add @friggframework/api-module-salesforce@1.0.3-canary.84.ccad42b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-salesforce@2.0.0-next.3`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat(pipedrive): add findUsers method for /v1/users/find endpoint [#83](https://github.com/friggframework/api-module-library/pull/83) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-salesforce`
    - fix(salesforce): fix OAuth flow bugs and add unit tests [#84](https://github.com/friggframework/api-module-library/pull/84) ([@roboli](https://github.com/roboli))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
