### PR TITLE
feat(pipedrive): add listLeads and getLead API methods

### DIFF
--- a/packages/v1-ready/pipedrive/src/api.ts
+++ b/packages/v1-ready/pipedrive/src/api.ts
@@ -523,16 +523,15 @@ export class Api extends OAuth2Requester {
   /**
    * List leads with optional filtering
    * @param params - Query parameters for filtering and pagination
-   * @param params.limit - Number of leads to return (default 100, max 500)
-   * @param params.cursor - Pagination cursor from previous response
-   * @param params.archived_status - Filter by archived status: 'archived' | 'not_archived' | 'all' (default: 'not_archived')
+   * @param params.limit - Number of leads to return (default 100)
+   * @param params.start - Pagination start position
    * @param params.owner_id - Filter by owner user ID
    * @param params.person_id - Filter by associated person ID
-   * @param params.org_id - Filter by associated organization ID
+   * @param params.organization_id - Filter by associated organization ID
    * @param params.filter_id - Filter by saved filter ID
-   * @param params.sort_by - Field to sort by
-   * @param params.sort_direction - Sort direction: 'asc' | 'desc'
-   * @returns Response with lead data array and pagination cursor
+   * @param params.updated_since - Return leads updated at or after this time (ISO 8601)
+   * @param params.sort - Field and direction e.g. "update_time DESC"
+   * @returns Response with lead data array
    */
   async listLeads(params?: ListLeadsParams): Promise<PipedriveResponse> {
     const options: RequestOptions = {

--- a/packages/v1-ready/pipedrive/src/api.ts
+++ b/packages/v1-ready/pipedrive/src/api.ts
@@ -19,6 +19,7 @@ import {
   CreateCallLogParams,
   UpdateCallLogParams,
   ListCallLogsParams,
+  ListLeadsParams,
 } from "./types";
 
 export class Api extends OAuth2Requester {
@@ -42,6 +43,8 @@ export class Api extends OAuth2Requester {
     search: string;
     callLogs: string;
     callLogById: (callLogId: string) => string;
+    leads: string;
+    leadById: (leadId: string) => string;
   };
 
   constructor(params: OAuth2RequesterOptions) {
@@ -71,6 +74,8 @@ export class Api extends OAuth2Requester {
       search: "/v1/search",
       callLogs: "/v1/callLogs",
       callLogById: (callLogId: string) => `/v1/callLogs/${callLogId}`,
+      leads: "/v1/leads",
+      leadById: (leadId: string) => `/v1/leads/${leadId}`,
     };
 
     this.authorizationUri = encodeURI(
@@ -512,5 +517,42 @@ export class Api extends OAuth2Requester {
       url: this.baseUrl + this.URLs.callLogById(callLogId),
     };
     return this._delete(options);
+  }
+
+  // **************************   Leads   **********************************
+  /**
+   * List leads with optional filtering
+   * @param params - Query parameters for filtering and pagination
+   * @param params.limit - Number of leads to return (default 100, max 500)
+   * @param params.cursor - Pagination cursor from previous response
+   * @param params.archived_status - Filter by archived status: 'archived' | 'not_archived' | 'all' (default: 'not_archived')
+   * @param params.owner_id - Filter by owner user ID
+   * @param params.person_id - Filter by associated person ID
+   * @param params.org_id - Filter by associated organization ID
+   * @param params.filter_id - Filter by saved filter ID
+   * @param params.sort_by - Field to sort by
+   * @param params.sort_direction - Sort direction: 'asc' | 'desc'
+   * @returns Response with lead data array and pagination cursor
+   */
+  async listLeads(params?: ListLeadsParams): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.leads,
+    };
+    if (params && Object.keys(params).length > 0) {
+      options.query = params;
+    }
+    return this._get(options);
+  }
+
+  /**
+   * Get a single lead by ID
+   * @param leadId - The UUID of the lead to retrieve
+   * @returns Response with lead data
+   */
+  async getLead(leadId: string): Promise<PipedriveResponse> {
+    const options: RequestOptions = {
+      url: this.baseUrl + this.URLs.leadById(leadId),
+    };
+    return this._get(options);
   }
 }

--- a/packages/v1-ready/pipedrive/src/types.d.ts
+++ b/packages/v1-ready/pipedrive/src/types.d.ts
@@ -93,6 +93,18 @@ export interface ListDealsParams {
   custom_fields?: string; // Comma-separated keys, max 15
 }
 
+export interface ListLeadsParams {
+  limit?: number; // Default 100, max 500
+  cursor?: string;
+  archived_status?: 'archived' | 'not_archived' | 'all';
+  owner_id?: number;
+  person_id?: number;
+  org_id?: number;
+  filter_id?: number;
+  sort_by?: 'id' | 'update_time' | 'add_time' | 'next_activity_time' | 'value';
+  sort_direction?: 'asc' | 'desc';
+}
+
 export interface ListActivitiesParams {
   cursor?: string;
   limit?: number; // Default 100, max 500

--- a/packages/v1-ready/pipedrive/src/types.d.ts
+++ b/packages/v1-ready/pipedrive/src/types.d.ts
@@ -94,15 +94,14 @@ export interface ListDealsParams {
 }
 
 export interface ListLeadsParams {
-  limit?: number; // Default 100, max 500
-  cursor?: string;
-  archived_status?: 'archived' | 'not_archived' | 'all';
+  limit?: number; // Default 100
+  start?: number; // Pagination start position
   owner_id?: number;
   person_id?: number;
-  org_id?: number;
+  organization_id?: number;
   filter_id?: number;
-  sort_by?: 'id' | 'update_time' | 'add_time' | 'next_activity_time' | 'value';
-  sort_direction?: 'asc' | 'desc';
+  updated_since?: string; // ISO 8601 format
+  sort?: string; // Field and direction e.g. "update_time DESC", supports: id, title, owner_id, creator_id, was_seen, expected_close_date, next_activity_id, add_time, update_time
 }
 
 export interface ListActivitiesParams {


### PR DESCRIPTION
## Summary

- Adds `listLeads(params?)` — `GET /v1/leads` with filtering by `person_id`, `organization_id`, `owner_id`, `filter_id`, `updated_since`, `sort`, and offset pagination (`start`)
- Adds `getLead(leadId)` — `GET /v1/leads/{id}` for fetching a single lead by UUID
- Adds `ListLeadsParams` type to `types.d.ts`, verified against the official Pipedrive API docs

## Why

Required by `quo--frigg` to support routing call activities to a Leads destination alongside the existing Contact and Deal options.

## Test plan

- [ ] `listLeads()` with no params returns leads array
- [ ] `listLeads({ person_id })` filters correctly
- [ ] `getLead(id)` returns a single lead by UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-pipedrive@2.0.1-canary.85.e06e81d.0
  # or 
  yarn add @friggframework/api-module-pipedrive@2.0.1-canary.85.e06e81d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-pipedrive@2.1.0-next.7`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-pipedrive`
    - feat(pipedrive): add listLeads and getLead API methods [#85](https://github.com/friggframework/api-module-library/pull/85) ([@roboli](https://github.com/roboli))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat(pipedrive): add findUsers method for /v1/users/find endpoint [#83](https://github.com/friggframework/api-module-library/pull/83) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix(salesforce): fix OAuth flow bugs and add unit tests [#84](https://github.com/friggframework/api-module-library/pull/84) ([@roboli](https://github.com/roboli))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
