### PR TITLE
fix(salesforce): persist PKCE code_verifier via OAuth state parameter

### DIFF
--- a/packages/v1-ready/salesforce/api.js
+++ b/packages/v1-ready/salesforce/api.js
@@ -41,7 +41,7 @@ class Api extends OAuth2Requester {
 
     getAuthorizationUri() {
         const url = this.oauth2.getAuthorizationUrl({ scope: this.scope });
-        const verifier = this.oauth2._codeVerifier;
+        const verifier = this.oauth2.codeVerifier;
         if (verifier) {
             const urlObj = new URL(url);
             urlObj.searchParams.set('state', this._encryptVerifier(verifier));
@@ -52,8 +52,8 @@ class Api extends OAuth2Requester {
 
     restoreVerifierFromState(encryptedState) {
         const verifier = this._decryptVerifier(encryptedState);
-        this.oauth2._codeVerifier = verifier;
-        this.conn.oauth2._codeVerifier = verifier;
+        this.oauth2.codeVerifier = verifier;
+        this.conn.oauth2.codeVerifier = verifier;
     }
 
     _encryptVerifier(verifier) {

--- a/packages/v1-ready/salesforce/api.js
+++ b/packages/v1-ready/salesforce/api.js
@@ -1,5 +1,6 @@
 const { get, OAuth2Requester } = require('@friggframework/core');
 const jsforce = require('jsforce');
+const crypto = require('crypto');
 
 class Api extends OAuth2Requester {
     constructor(params) {
@@ -40,19 +41,39 @@ class Api extends OAuth2Requester {
 
     getAuthorizationUri() {
         const url = this.oauth2.getAuthorizationUrl({ scope: this.scope });
-        // Encode the PKCE code_verifier in state so it survives the stateless redirect
         const verifier = this.oauth2._codeVerifier;
         if (verifier) {
             const urlObj = new URL(url);
-            urlObj.searchParams.set('state', verifier);
+            urlObj.searchParams.set('state', this._encryptVerifier(verifier));
             return urlObj.toString();
         }
         return url;
     }
 
-    setCodeVerifier(verifier) {
+    restoreVerifierFromState(encryptedState) {
+        const verifier = this._decryptVerifier(encryptedState);
         this.oauth2._codeVerifier = verifier;
         this.conn.oauth2._codeVerifier = verifier;
+    }
+
+    _encryptVerifier(verifier) {
+        const key = crypto.createHash('sha256').update(this.client_secret).digest();
+        const iv = crypto.randomBytes(12);
+        const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+        const encrypted = Buffer.concat([cipher.update(verifier, 'utf8'), cipher.final()]);
+        const tag = cipher.getAuthTag();
+        return `${iv.toString('base64url')}.${encrypted.toString('base64url')}.${tag.toString('base64url')}`;
+    }
+
+    _decryptVerifier(encryptedState) {
+        const [ivB64, encB64, tagB64] = encryptedState.split('.');
+        const key = crypto.createHash('sha256').update(this.client_secret).digest();
+        const iv = Buffer.from(ivB64, 'base64url');
+        const encryptedBuf = Buffer.from(encB64, 'base64url');
+        const tag = Buffer.from(tagB64, 'base64url');
+        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+        decipher.setAuthTag(tag);
+        return Buffer.concat([decipher.update(encryptedBuf), decipher.final()]).toString('utf8');
     }
 
     resetToSandbox() {

--- a/packages/v1-ready/salesforce/api.js
+++ b/packages/v1-ready/salesforce/api.js
@@ -39,7 +39,20 @@ class Api extends OAuth2Requester {
     }
 
     getAuthorizationUri() {
-        return this.oauth2.getAuthorizationUrl({ scope: this.scope });
+        const url = this.oauth2.getAuthorizationUrl({ scope: this.scope });
+        // Encode the PKCE code_verifier in state so it survives the stateless redirect
+        const verifier = this.oauth2._codeVerifier;
+        if (verifier) {
+            const urlObj = new URL(url);
+            urlObj.searchParams.set('state', verifier);
+            return urlObj.toString();
+        }
+        return url;
+    }
+
+    setCodeVerifier(verifier) {
+        this.oauth2._codeVerifier = verifier;
+        this.conn.oauth2._codeVerifier = verifier;
     }
 
     resetToSandbox() {

--- a/packages/v1-ready/salesforce/definition.js
+++ b/packages/v1-ready/salesforce/definition.js
@@ -19,7 +19,7 @@ const Definition = {
         },
         getToken: async function (api, params) {
             const code = get(params, 'code');
-            const state = get(params, 'state');
+            const state = get(params, 'state', null);
             if (state) api.restoreVerifierFromState(state);
             let tokenResponse;
             try {

--- a/packages/v1-ready/salesforce/definition.js
+++ b/packages/v1-ready/salesforce/definition.js
@@ -19,6 +19,8 @@ const Definition = {
         },
         getToken: async function (api, params) {
             const code = get(params, 'code');
+            const state = get(params, 'state');
+            if (state) api.setCodeVerifier(state);
             let tokenResponse;
             try {
                 tokenResponse = await api.getAccessToken(code);
@@ -27,6 +29,7 @@ const Definition = {
                 // Then try again
                 console.log(e);
                 api.resetToSandbox();
+                if (state) api.setCodeVerifier(state);
                 tokenResponse = await api.getAccessToken(code);
             }
             return tokenResponse;

--- a/packages/v1-ready/salesforce/definition.js
+++ b/packages/v1-ready/salesforce/definition.js
@@ -20,7 +20,7 @@ const Definition = {
         getToken: async function (api, params) {
             const code = get(params, 'code');
             const state = get(params, 'state');
-            if (state) api.setCodeVerifier(state);
+            if (state) api.restoreVerifierFromState(state);
             let tokenResponse;
             try {
                 tokenResponse = await api.getAccessToken(code);
@@ -29,7 +29,7 @@ const Definition = {
                 // Then try again
                 console.log(e);
                 api.resetToSandbox();
-                if (state) api.setCodeVerifier(state);
+                if (state) api.restoreVerifierFromState(state);
                 tokenResponse = await api.getAccessToken(code);
             }
             return tokenResponse;


### PR DESCRIPTION
## Problem

With `useVerifier: true` enabled (from #78), jsforce generates a `code_verifier` and stores it on the `jsforce.OAuth2` instance during `getAuthorizationUri()`. In a stateless serverless environment, that instance is gone by the time the callback arrives — a new `Api` instance is created for the token exchange, with a fresh `jsforce.OAuth2` that has no `code_verifier`. Salesforce rejects the exchange with **"invalid code verifier"**.

## Fix

Encode the `code_verifier` in the OAuth `state` parameter when building the authorization URL. Salesforce echoes `state` back in the callback, so `getToken()` in `definition.js` can restore it on the new instance before calling `getAccessToken()`. Also restores after `resetToSandbox()` since that creates a fresh `jsforce.OAuth2`.

## Changes

- `api.js` — `getAuthorizationUri()` extracts `this.oauth2._codeVerifier` after URL generation and sets it as the `state` param
- `api.js` — new `setCodeVerifier(verifier)` method sets verifier on both `this.oauth2` and `this.conn.oauth2`
- `definition.js` — `getToken()` reads `params.state`, calls `api.setCodeVerifier()` before token exchange and again after `resetToSandbox()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-salesforce@1.0.3-canary.86.18311b8.0
  # or 
  yarn add @friggframework/api-module-salesforce@1.0.3-canary.86.18311b8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-salesforce@2.0.0-next.5`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-salesforce`
    - fix(salesforce): persist PKCE code_verifier via OAuth state parameter [#86](https://github.com/friggframework/api-module-library/pull/86) ([@roboli](https://github.com/roboli))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix(salesforce): enable PKCE and sync auth requirements [#78](https://github.com/friggframework/api-module-library/pull/78) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
