### PR TITLE
fix: prevent PKCE verifier from being sent on Salesforce token refresh

### DIFF
--- a/packages/v1-ready/salesforce/api.js
+++ b/packages/v1-ready/salesforce/api.js
@@ -20,7 +20,6 @@ class Api extends OAuth2Requester {
             clientSecret: this.client_secret,
             redirectUri: this.redirect_uri,
             loginUrl: this.loginUrl,
-            useVerifier: true,
         });
         this.conn = new jsforce.Connection({
             oauth2: this.oauth2,
@@ -40,6 +39,18 @@ class Api extends OAuth2Requester {
     }
 
     getAuthorizationUri() {
+        // Recreate oauth2 with a fresh PKCE verifier for this auth flow only.
+        // We don't keep useVerifier: true on the long-lived instance because
+        // jsforce would send the stale verifier on every token refresh, which
+        // Salesforce rejects with "unexpected code verifier".
+        this.oauth2 = new jsforce.OAuth2({
+            clientId: this.client_id,
+            clientSecret: this.client_secret,
+            redirectUri: this.redirect_uri,
+            loginUrl: this.loginUrl,
+            useVerifier: true,
+        });
+        this.conn.oauth2 = this.oauth2;
         const url = this.oauth2.getAuthorizationUrl({ scope: this.scope });
         const verifier = this.oauth2.codeVerifier;
         if (verifier) {
@@ -82,7 +93,6 @@ class Api extends OAuth2Requester {
             clientSecret: this.client_secret,
             redirectUri: this.redirect_uri,
             loginUrl: 'https://test.salesforce.com',
-            useVerifier: true,
         });
 
         this.conn = new jsforce.Connection({
@@ -114,6 +124,9 @@ class Api extends OAuth2Requester {
         //   automatically re-set the access token for future requests of the instance of the class and tells the
         //   delegate to update the DB for future requests.
         this.instanceUrl = this.conn.instanceUrl;
+        // Clear verifier so it is not sent on future token refreshes
+        this.oauth2.codeVerifier = null;
+        this.conn.oauth2.codeVerifier = null;
         await this.setTokens(OAuthDetails);
         return this.conn.accessToken;
     }


### PR DESCRIPTION
## Summary

- `jsforce` sends `code_verifier` on every token refresh when `useVerifier: true` is set on the `OAuth2` instance — Salesforce rejects this with `"unexpected code verifier"` because PKCE verifiers are only valid for the initial authorization code exchange, not for refresh token flows
- Removed `useVerifier: true` from the constructor and `resetToSandbox` so no stale verifier is present during normal API use
- `getAuthorizationUri` now recreates `oauth2` with a fresh verifier scoped to that auth flow only, and syncs it to `conn.oauth2`
- `getAccessToken` clears `codeVerifier` on both `oauth2` and `conn.oauth2` after the code exchange completes

## Test plan

- [ ] OAuth flow completes successfully (verifier sent on code exchange, not on refresh)
- [ ] Token refresh no longer throws `"unexpected code verifier"`
- [ ] Re-authorize and confirm sync works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-salesforce@1.0.3-canary.87.bd051f6.0
  # or 
  yarn add @friggframework/api-module-salesforce@1.0.3-canary.87.bd051f6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-salesforce@2.0.0-next.6`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-salesforce`
    - fix: prevent PKCE verifier from being sent on Salesforce token refresh [#87](https://github.com/friggframework/api-module-library/pull/87) ([@roboli](https://github.com/roboli))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix(salesforce): persist PKCE code_verifier via OAuth state parameter [#86](https://github.com/friggframework/api-module-library/pull/86) ([@roboli](https://github.com/roboli))
    - fix(salesforce): enable PKCE and sync auth requirements [#78](https://github.com/friggframework/api-module-library/pull/78) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
