### PR TITLE
feat(hubspot): add Webhooks v3 Subscriptions API methods

### DIFF
--- a/packages/v1-ready/hubspot/api.js
+++ b/packages/v1-ready/hubspot/api.js
@@ -71,7 +71,9 @@ class Api extends OAuth2Requester {
             listMembershipsAddRemove: (listId) => `/crm/v3/lists/${listId}/memberships/add-and-remove`,
             associations: (fromObject, toObject) => `/crm/v4/associations/${fromObject}/${toObject}`,
             associationLabels: (fromObject, toObject) => `/crm/v4/associations/${fromObject}/${toObject}/labels`,
-
+            webhookSubscriptions: (appId) => `/webhooks/v3/${appId}/subscriptions`,
+            webhookSubscriptionById: (appId, subscriptionId) =>
+                `/webhooks/v3/${appId}/subscriptions/${subscriptionId}`,
         };
 
         this.authorizationUri = encodeURI(
@@ -1007,7 +1009,87 @@ class Api extends OAuth2Requester {
         return this.addAndRemoveFromList(listId, [], recordIds);
     }
 
+    // **************************   Webhook Subscriptions   **********************************
+    //
+    // App-level Webhooks v3 Subscriptions API. Auth is the developer-account
+    // API key (Bearer), distinct from the per-portal OAuth flow the rest of
+    // this Api class uses. Endpoints accept { appId, developerApiKey } so
+    // callers control identity per-call without mutating Api instance state.
 
+    async listWebhookSubscriptions({ appId, developerApiKey }) {
+        const response = await this._developerFetch(
+            this.baseUrl + this.URLs.webhookSubscriptions(appId),
+            { method: 'GET' },
+            developerApiKey
+        );
+        await this._requireOk(response, 'listWebhookSubscriptions');
+        const body = await response.json();
+        return body.results ?? [];
+    }
+
+    async createWebhookSubscription({ appId, developerApiKey, subscriptionType, propertyName }) {
+        const subscriptionDetails = propertyName
+            ? { subscriptionType, propertyName }
+            : { subscriptionType };
+        const response = await this._developerFetch(
+            this.baseUrl + this.URLs.webhookSubscriptions(appId),
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ subscriptionDetails, enabled: true }),
+            },
+            developerApiKey
+        );
+        if (response.status === 409) {
+            return { status: 409, data: await this._safeJson(response) };
+        }
+        await this._requireOk(response, 'createWebhookSubscription');
+        return { status: response.status, data: await response.json() };
+    }
+
+    async deleteWebhookSubscription({ appId, developerApiKey, subscriptionId }) {
+        const response = await this._developerFetch(
+            this.baseUrl + this.URLs.webhookSubscriptionById(appId, subscriptionId),
+            { method: 'DELETE' },
+            developerApiKey
+        );
+        if (response.status === 404) return;
+        await this._requireOk(response, 'deleteWebhookSubscription');
+    }
+
+    async _developerFetch(url, init, developerApiKey) {
+        return fetch(url, {
+            ...init,
+            headers: {
+                ...init.headers,
+                Authorization: `Bearer ${developerApiKey}`,
+            },
+        });
+    }
+
+    async _requireOk(response, operation) {
+        if (response.ok) return;
+        const detail = await this._safeText(response);
+        throw new Error(
+            `HubSpot ${operation} failed: ${response.status} ${detail}`
+        );
+    }
+
+    async _safeJson(response) {
+        try {
+            return await response.json();
+        } catch {
+            return {};
+        }
+    }
+
+    async _safeText(response) {
+        try {
+            return await response.text();
+        } catch {
+            return '';
+        }
+    }
 }
 
 module.exports = {Api};

--- a/packages/v1-ready/hubspot/api.js
+++ b/packages/v1-ready/hubspot/api.js
@@ -1027,16 +1027,16 @@ class Api extends OAuth2Requester {
         return body.results ?? [];
     }
 
-    async createWebhookSubscription({ appId, developerApiKey, subscriptionType, propertyName }) {
-        const subscriptionDetails = propertyName
-            ? { subscriptionType, propertyName }
-            : { subscriptionType };
+    async createWebhookSubscription({ appId, developerApiKey, eventType, propertyName }) {
+        const body = propertyName
+            ? { eventType, propertyName, active: true }
+            : { eventType, active: true };
         const response = await this._developerFetch(
             this.baseUrl + this.URLs.webhookSubscriptions(appId),
             {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ subscriptionDetails, enabled: true }),
+                body: JSON.stringify(body),
             },
             developerApiKey
         );

--- a/packages/v1-ready/hubspot/tests/webhook-subscriptions.test.js
+++ b/packages/v1-ready/hubspot/tests/webhook-subscriptions.test.js
@@ -87,9 +87,7 @@ describe('HubSpot Webhook Subscriptions', () => {
                 status: 201,
                 body: {
                     id: 7,
-                    subscriptionDetails: {
-                        subscriptionType: 'contact.creation',
-                    },
+                    eventType: 'contact.creation',
                     active: true,
                 },
             })
@@ -98,7 +96,7 @@ describe('HubSpot Webhook Subscriptions', () => {
         const result = await api.createWebhookSubscription({
             appId: APP_ID,
             developerApiKey: DEVELOPER_API_KEY,
-            subscriptionType: 'contact.creation',
+            eventType: 'contact.creation',
         });
 
         const [url, opts] = fetchMock.mock.calls[0];
@@ -107,8 +105,8 @@ describe('HubSpot Webhook Subscriptions', () => {
         expect(opts.headers.Authorization).toBe(`Bearer ${DEVELOPER_API_KEY}`);
         expect(opts.headers['Content-Type']).toBe('application/json');
         expect(JSON.parse(opts.body)).toEqual({
-            subscriptionDetails: { subscriptionType: 'contact.creation' },
-            enabled: true,
+            eventType: 'contact.creation',
+            active: true,
         });
         expect(result.status).toBe(201);
         expect(result.data.id).toBe(7);
@@ -122,14 +120,15 @@ describe('HubSpot Webhook Subscriptions', () => {
         await api.createWebhookSubscription({
             appId: APP_ID,
             developerApiKey: DEVELOPER_API_KEY,
-            subscriptionType: 'contact.propertyChange',
+            eventType: 'contact.propertyChange',
             propertyName: 'email',
         });
 
         const [, opts] = fetchMock.mock.calls[0];
-        expect(JSON.parse(opts.body).subscriptionDetails).toEqual({
-            subscriptionType: 'contact.propertyChange',
+        expect(JSON.parse(opts.body)).toEqual({
+            eventType: 'contact.propertyChange',
             propertyName: 'email',
+            active: true,
         });
     });
 
@@ -145,7 +144,7 @@ describe('HubSpot Webhook Subscriptions', () => {
         const result = await api.createWebhookSubscription({
             appId: APP_ID,
             developerApiKey: DEVELOPER_API_KEY,
-            subscriptionType: 'contact.creation',
+            eventType: 'contact.creation',
         });
 
         expect(result.status).toBe(409);
@@ -161,7 +160,7 @@ describe('HubSpot Webhook Subscriptions', () => {
             api.createWebhookSubscription({
                 appId: APP_ID,
                 developerApiKey: DEVELOPER_API_KEY,
-                subscriptionType: 'contact.creation',
+                eventType: 'contact.creation',
             })
         ).rejects.toThrow(/400/);
     });

--- a/packages/v1-ready/hubspot/tests/webhook-subscriptions.test.js
+++ b/packages/v1-ready/hubspot/tests/webhook-subscriptions.test.js
@@ -1,0 +1,209 @@
+const { Api } = require('../api');
+
+function makeResponse({ ok = true, status, body = {} } = {}) {
+    return {
+        ok,
+        status: status ?? (ok ? 200 : 500),
+        text: async () =>
+            typeof body === 'string' ? body : JSON.stringify(body),
+        json: async () =>
+            typeof body === 'string' ? JSON.parse(body) : body,
+    };
+}
+
+const APP_ID = 'app-42';
+const DEVELOPER_API_KEY = 'dev-key-xyz';
+const BASE = 'https://api.hubapi.com';
+
+describe('HubSpot Webhook Subscriptions', () => {
+    let originalFetch;
+    let fetchMock;
+
+    beforeEach(() => {
+        originalFetch = global.fetch;
+        fetchMock = jest.fn();
+        global.fetch = fetchMock;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    const api = new Api({
+        client_id: 'unused-for-developer-endpoints',
+        client_secret: 'unused-for-developer-endpoints',
+    });
+
+    test('listWebhookSubscriptions GETs /webhooks/v3/{appId}/subscriptions with Bearer auth', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({ ok: true, body: { results: [] } })
+        );
+
+        await api.listWebhookSubscriptions({
+            appId: APP_ID,
+            developerApiKey: DEVELOPER_API_KEY,
+        });
+
+        const [url, opts] = fetchMock.mock.calls[0];
+        expect(url).toBe(`${BASE}/webhooks/v3/${APP_ID}/subscriptions`);
+        expect(opts.method).toBe('GET');
+        expect(opts.headers.Authorization).toBe(`Bearer ${DEVELOPER_API_KEY}`);
+        expect(url).not.toContain('hapikey');
+    });
+
+    test('listWebhookSubscriptions returns the parsed results array', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({
+                ok: true,
+                body: { results: [{ id: 1 }, { id: 2 }] },
+            })
+        );
+
+        const result = await api.listWebhookSubscriptions({
+            appId: APP_ID,
+            developerApiKey: DEVELOPER_API_KEY,
+        });
+
+        expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    test('listWebhookSubscriptions throws on non-2xx', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({ ok: false, status: 403, body: 'forbidden' })
+        );
+
+        await expect(
+            api.listWebhookSubscriptions({
+                appId: APP_ID,
+                developerApiKey: DEVELOPER_API_KEY,
+            })
+        ).rejects.toThrow(/403/);
+    });
+
+    test('createWebhookSubscription POSTs the spec body with Bearer auth', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({
+                ok: true,
+                status: 201,
+                body: {
+                    id: 7,
+                    subscriptionDetails: {
+                        subscriptionType: 'contact.creation',
+                    },
+                    active: true,
+                },
+            })
+        );
+
+        const result = await api.createWebhookSubscription({
+            appId: APP_ID,
+            developerApiKey: DEVELOPER_API_KEY,
+            subscriptionType: 'contact.creation',
+        });
+
+        const [url, opts] = fetchMock.mock.calls[0];
+        expect(url).toBe(`${BASE}/webhooks/v3/${APP_ID}/subscriptions`);
+        expect(opts.method).toBe('POST');
+        expect(opts.headers.Authorization).toBe(`Bearer ${DEVELOPER_API_KEY}`);
+        expect(opts.headers['Content-Type']).toBe('application/json');
+        expect(JSON.parse(opts.body)).toEqual({
+            subscriptionDetails: { subscriptionType: 'contact.creation' },
+            enabled: true,
+        });
+        expect(result.status).toBe(201);
+        expect(result.data.id).toBe(7);
+    });
+
+    test('createWebhookSubscription includes propertyName when provided', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({ ok: true, status: 201, body: { id: 8 } })
+        );
+
+        await api.createWebhookSubscription({
+            appId: APP_ID,
+            developerApiKey: DEVELOPER_API_KEY,
+            subscriptionType: 'contact.propertyChange',
+            propertyName: 'email',
+        });
+
+        const [, opts] = fetchMock.mock.calls[0];
+        expect(JSON.parse(opts.body).subscriptionDetails).toEqual({
+            subscriptionType: 'contact.propertyChange',
+            propertyName: 'email',
+        });
+    });
+
+    test('createWebhookSubscription returns the 409 conflict response without throwing', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({
+                ok: false,
+                status: 409,
+                body: { message: 'already exists' },
+            })
+        );
+
+        const result = await api.createWebhookSubscription({
+            appId: APP_ID,
+            developerApiKey: DEVELOPER_API_KEY,
+            subscriptionType: 'contact.creation',
+        });
+
+        expect(result.status).toBe(409);
+        expect(result.data.message).toBe('already exists');
+    });
+
+    test('createWebhookSubscription throws on other non-2xx responses', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({ ok: false, status: 400, body: 'validation failed' })
+        );
+
+        await expect(
+            api.createWebhookSubscription({
+                appId: APP_ID,
+                developerApiKey: DEVELOPER_API_KEY,
+                subscriptionType: 'contact.creation',
+            })
+        ).rejects.toThrow(/400/);
+    });
+
+    test('deleteWebhookSubscription DELETEs the sub-specific URL with Bearer auth', async () => {
+        fetchMock.mockResolvedValue(makeResponse({ ok: true, status: 204 }));
+
+        await api.deleteWebhookSubscription({
+            appId: APP_ID,
+            developerApiKey: DEVELOPER_API_KEY,
+            subscriptionId: '99',
+        });
+
+        const [url, opts] = fetchMock.mock.calls[0];
+        expect(url).toBe(`${BASE}/webhooks/v3/${APP_ID}/subscriptions/99`);
+        expect(opts.method).toBe('DELETE');
+        expect(opts.headers.Authorization).toBe(`Bearer ${DEVELOPER_API_KEY}`);
+    });
+
+    test('deleteWebhookSubscription tolerates 404 (idempotent)', async () => {
+        fetchMock.mockResolvedValue(makeResponse({ ok: false, status: 404 }));
+
+        await expect(
+            api.deleteWebhookSubscription({
+                appId: APP_ID,
+                developerApiKey: DEVELOPER_API_KEY,
+                subscriptionId: '99',
+            })
+        ).resolves.toBeUndefined();
+    });
+
+    test('deleteWebhookSubscription throws on other non-2xx errors', async () => {
+        fetchMock.mockResolvedValue(
+            makeResponse({ ok: false, status: 500, body: 'boom' })
+        );
+
+        await expect(
+            api.deleteWebhookSubscription({
+                appId: APP_ID,
+                developerApiKey: DEVELOPER_API_KEY,
+                subscriptionId: '99',
+            })
+        ).rejects.toThrow(/500/);
+    });
+});


### PR DESCRIPTION
## Summary

Adds three methods to the HubSpot `Api` class for managing app-level webhook subscriptions:

- `listWebhookSubscriptions({ appId, developerApiKey })`
- `createWebhookSubscription({ appId, developerApiKey, subscriptionType, propertyName })`
- `deleteWebhookSubscription({ appId, developerApiKey, subscriptionId })`

## Why

Webhooks v3 Subscriptions is the API HubSpot apps use to subscribe to lifecycle / property-change events on contacts/companies/deals/etc. Right now consumers of `@friggframework/api-module-hubspot` have to roll their own HTTP layer for these endpoints — defeating the api-module's purpose of being the single home for HubSpot HTTP surface.

Reference: https://developers.hubspot.com/docs/api-reference/webhooks-webhooks-v3

## Design notes

**Auth is different from the rest of this Api class.** Most endpoints use the per-portal OAuth bearer (`access_token` set by the OAuth2Requester). Webhooks v3 Subscriptions is **app-level**, identified by the **developer-account API key** — same `Authorization: Bearer` header but a different identity. Rather than mutate instance state (`access_token`) per-call, the new methods take `appId` + `developerApiKey` as parameters and use `fetch` directly with explicit headers. The endpoint URLs stay declared in the `URLs` map for consistency.

**Note on `hapikey`:** HubSpot deprecated the `hapikey` query-param auth in Nov 2022. These methods use the modern Bearer-header form.

**409 / 404 semantics:**
- `createWebhookSubscription` returns `{ status, data }` instead of throwing on 409, so callers can treat "already exists" as success in race conditions (e.g. two parallel handlers racing to register the same subscription).
- `deleteWebhookSubscription` silently swallows 404 (subscription already gone — desired state achieved).
- Other non-2xx responses throw with `${status} ${response body}` for context.

## Test plan

- [x] 10 new unit tests in `packages/v1-ready/hubspot/tests/webhook-subscriptions.test.js` mocking `global.fetch`. Covers: happy-path GET/POST/DELETE, propertyName forwarding, 409 idempotency, 404 idempotency, error pathways.
- [x] Existing test suite untouched (the new methods don't interact with the OAuth2 flow).
- [ ] End-to-end smoke against a real HubSpot dev account (manual, not in CI).

## Downstream usage

This unblocks https://github.com/ClockworkRecruiting/integrations/pull/12 which adds webhook-driven ongoing sync between HubSpot and Clockwork via Frigg. Without these methods landing here, the downstream PR has to maintain its own HTTP surface for the same endpoints — exactly what api-modules exist to prevent.