### PR TITLE
fix(hubspot): coerce portalId to String for externalId

### DIFF
--- a/packages/v1-ready/hubspot/definition.js
+++ b/packages/v1-ready/hubspot/definition.js
@@ -18,7 +18,7 @@ const Definition = {
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: userDetails.portalId, userId},
+                identifiers: {externalId: String(userDetails.portalId), userId},
                 details: {name: userDetails.hub_domain},
             }
         },
@@ -31,7 +31,7 @@ const Definition = {
         getCredentialDetails: async function (api, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: userDetails.portalId, userId},
+                identifiers: {externalId: String(userDetails.portalId), userId},
                 details: {}
             };
         },

--- a/packages/v1-ready/hubspot/tests/definition.test.js
+++ b/packages/v1-ready/hubspot/tests/definition.test.js
@@ -1,0 +1,67 @@
+/**
+ * Definition unit tests — assert the shape of identifiers handed to
+ * Frigg core during the auth handshake. The Postgres schema in
+ * @friggframework/core ≥ 2.0.0-next types Credential.externalId as
+ * String?, so portalId (Int from HubSpot's /access-tokens response)
+ * must be stringified at the api-module boundary.
+ */
+
+const { Definition } = require('../definition');
+
+const baseUserDetails = {
+    portalId: 111111111, // HubSpot returns this as an integer
+    hub_domain: 'Testing Object Things-dev-44613847.com',
+    hub_id: 111111111,
+};
+
+function makeStubApi(userDetailsOverride = {}) {
+    return {
+        getUserDetails: async () =>
+            Object.assign({}, baseUserDetails, userDetailsOverride),
+    };
+}
+
+describe('HubSpot Definition externalId coercion', () => {
+    describe('getEntityDetails()', () => {
+        it('returns externalId as a string, not an integer', async () => {
+            const api = makeStubApi();
+            const result =
+                await Definition.requiredAuthMethods.getEntityDetails(
+                    api,
+                    null,
+                    null,
+                    42
+                );
+
+            expect(typeof result.identifiers.externalId).toBe('string');
+            expect(result.identifiers.externalId).toBe('111111111');
+        });
+
+        it('stringifies a very large portalId without losing precision', async () => {
+            const api = makeStubApi({ portalId: 9999999999 });
+            const result =
+                await Definition.requiredAuthMethods.getEntityDetails(
+                    api,
+                    null,
+                    null,
+                    42
+                );
+
+            expect(result.identifiers.externalId).toBe('9999999999');
+        });
+    });
+
+    describe('getCredentialDetails()', () => {
+        it('returns externalId as a string, not an integer', async () => {
+            const api = makeStubApi();
+            const result =
+                await Definition.requiredAuthMethods.getCredentialDetails(
+                    api,
+                    42
+                );
+
+            expect(typeof result.identifiers.externalId).toBe('string');
+            expect(result.identifiers.externalId).toBe('111111111');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Frigg core's Postgres schema (>= `2.0.0-next`) types `Credential.externalId` and `Entity.externalId` as `String?`, but HubSpot's `/account-info` endpoint returns `portalId` as an integer.
- The auth handshake throws `PrismaClientValidationError` on credential lookup whenever the api-module is paired with the new core:
  ```
  Argument `externalId`: Invalid value provided.
  Expected StringNullableFilter, String or Null, provided Int.
  ```
- Coerces `userDetails.portalId` to `String(...)` at the boundary in both `getEntityDetails` and `getCredentialDetails`.

## Why this matters
With `@friggframework/core@2.0.0-next.86` the Prisma error is non-fatal during initial create (the fallback path eventually writes the credential as `Int` because Prisma actually accepts whatever the JS driver coerces), but it surfaces as a hard validation failure on every subsequent `findFirst({ externalId: <number> })` — including refresh-token lookups. Reproduced live against a portal during a fresh seed of 500 contacts.

## Test plan
- [x] Added focused unit tests in `tests/definition.test.js` that pin the contract independently of the broader `testAutherDefinition` suite (which requires DB).
- [x] All three new tests fail before the fix, pass after.
- [x] Pre-existing `auther.test.js` failure (`retrieves existing entity on subsequent calls`) is unchanged — confirmed on `origin/next` before applying the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-hubspot@2.0.0-next.3`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-clio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat(clio): add Clio API module package [#88](https://github.com/friggframework/api-module-library/pull/88) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-hubspot`
    - fix(hubspot): coerce portalId to String for externalId [#90](https://github.com/friggframework/api-module-library/pull/90) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
