### PR TITLE
fix(hubspot): listContacts omits null `after` so it can paginate past page 1

### DIFF
--- a/packages/v1-ready/hubspot/api.js
+++ b/packages/v1-ready/hubspot/api.js
@@ -213,13 +213,19 @@ class Api extends OAuth2Requester {
             properties = await this._propertiesList('contact');
         }
 
+        const query = { limit, properties };
+        // HubSpot rejects `after=null`/`after=` with a 400, so only send the
+        // paging cursor once we actually have one (i.e. from the second page
+        // onward). Without this guard, paging past the first page is impossible
+        // and callers are forced onto the search endpoint, which is hard-capped
+        // at 10,000 results.
+        if (after !== null && after !== undefined && after !== '') {
+            query.after = after;
+        }
+
         const options = {
             url: this.baseUrl + this.URLs.contacts,
-            query: {
-                limit,
-                after,
-                properties,
-            }
+            query,
         };
 
         return this._get(options);

--- a/packages/v1-ready/hubspot/tests/listContacts.test.js
+++ b/packages/v1-ready/hubspot/tests/listContacts.test.js
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for Api.listContacts pagination query-building.
+ *
+ * The module's other tests (api.test.js) are live-OAuth integration tests that
+ * require real HubSpot credentials. These are fast unit tests that stub the
+ * underlying `_get` so we can assert the request query without a network call.
+ */
+const { Api } = require('../api');
+
+describe('Api.listContacts pagination', () => {
+    function makeApi() {
+        const api = new Api({});
+        api._get = jest.fn().mockResolvedValue({ results: [], paging: {} });
+        return api;
+    }
+
+    it('omits `after` from the query on the first page (no cursor)', async () => {
+        const api = makeApi();
+        await api.listContacts({ limit: 100, properties: ['email'] });
+
+        expect(api._get).toHaveBeenCalledTimes(1);
+        const { query } = api._get.mock.calls[0][0];
+        // HubSpot 400s on `after=null`; the first page must not send it at all.
+        expect(query).not.toHaveProperty('after');
+        expect(query.limit).toBe(100);
+        expect(query.properties).toEqual(['email']);
+    });
+
+    it('sends `after` from the second page onward', async () => {
+        const api = makeApi();
+        await api.listContacts({
+            after: '12345',
+            limit: 100,
+            properties: ['email'],
+        });
+
+        expect(api._get.mock.calls[0][0].query.after).toBe('12345');
+    });
+
+    it('treats null `after` as "no cursor"', async () => {
+        const api = makeApi();
+        await api.listContacts({
+            after: null,
+            limit: 100,
+            properties: ['email'],
+        });
+
+        expect(api._get.mock.calls[0][0].query).not.toHaveProperty('after');
+    });
+});


### PR DESCRIPTION
## Problem

`Api.listContacts` always places `after` in the query string, defaulting it to `null` when no cursor is supplied:

```js
const after = get(params, 'after', null);
// ...
query: { limit, after, properties }
```

HubSpot's `GET /crm/v3/objects/contacts` rejects `after=null` (and `after=`) with a **400**, so a caller can never page past the first page. The practical fallout: integrations are forced onto the **search** endpoint for full enumeration, which HubSpot **hard-caps at 10,000 results** — so any portal with >10k contacts cannot be fully listed. (We hit exactly this: a 100k-contact initial sync died at `fetched=10000`.)

## Fix

Only include `after` in the query once a cursor is actually present (i.e. from the second page onward). First-page calls now send just `limit` + `properties`; subsequent pages send the `paging.next.after` cursor.

```js
const query = { limit, properties };
if (after !== null && after !== undefined && after !== '') {
    query.after = after;
}
```

## Tests

New `tests/listContacts.test.js` (fast unit tests stubbing `_get`, since the existing `api.test.js` is live-OAuth):
- first page (no cursor) → query has no `after`
- subsequent page → `after` is sent
- `after: null` → treated as "no cursor"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-hubspot@2.0.0-next.6`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-clio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat(hubspot): DB-free webhook receiver via 2-hop resolve [#92](https://github.com/friggframework/api-module-library/pull/92) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - feat(api): prevent calling setTokens on Zoho API error [#76](https://github.com/friggframework/api-module-library/pull/76) ([@d-klotz](https://github.com/d-klotz))
  
  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-hubspot`
    - fix(hubspot): listContacts omits null `after` so it can paginate past page 1 [#93](https://github.com/friggframework/api-module-library/pull/93) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
