### PR TITLE
fix(hubspot): align getToken + getEntityDetails with current core contract

### DIFF
--- a/packages/v1-ready/hubspot/definition.js
+++ b/packages/v1-ready/hubspot/definition.js
@@ -12,13 +12,13 @@ const Definition = {
     modelName: 'HubSpot',
     requiredAuthMethods: {
         getToken: async function (api, params) {
-            const code = get(params.data, 'code');
+            const code = get(params, 'code');
             return api.getTokenFromCode(code);
         },
         getEntityDetails: async function (api, callbackParams, tokenResponse, userId) {
             const userDetails = await api.getUserDetails();
             return {
-                identifiers: {externalId: String(userDetails.portalId), userId},
+                identifiers: {externalId: String(userDetails.portalId), user: userId},
                 details: {name: userDetails.hub_domain},
             }
         },


### PR DESCRIPTION
## What

Two fixes to `packages/v1-ready/hubspot/definition.js` so the module's auth contract matches the current `@friggframework/core`:

- **`getToken`** — read the OAuth `code` from `params.code`. Current core's `process-authorization-callback` calls `getToken(api, params)` and itself reads `params.code`; the module was reading `params.data.code`, which is `undefined`.
- **`getEntityDetails`** — return the `user` identifier instead of `userId`. Core's `findOrCreateEntity` spreads the returned `identifiers` straight into the repository's `createEntity`, which keys the entity by `user`. The lookup path normalizes `user || userId`, but the create path persists whatever key is passed. `getCredentialDetails` intentionally stays on `userId` (the credential contract).

## Why

A downstream consumer (a Clockwork↔HubSpot integration) was working around both of these with a local `requiredAuthMethods` wrapper around `hubspot.Definition`. With this fix the wrapper is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-hubspot@2.0.0-next.7`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-hubspot`
    - fix(hubspot): align getToken + getEntityDetails with current core contract [#94](https://github.com/friggframework/api-module-library/pull/94) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-clio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix(hubspot): listContacts omits null `after` so it can paginate past page 1 [#93](https://github.com/friggframework/api-module-library/pull/93) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 1
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
