### PR TITLE
docs(salesforce): add Connected App setup instructions

### DIFF
--- a/packages/v1-ready/salesforce/README.md
+++ b/packages/v1-ready/salesforce/README.md
@@ -31,4 +31,6 @@ In the Connected App's OAuth policies, set **Refresh Token Policy** to **"Refres
 
 The Salesforce user who authorizes the OAuth connection must be marked as a **Marketing User**. This grants the integration permission to create and manage Campaigns in Salesforce — without it, campaign creation will fail.
 
-To enable it: **Setup → Users → [user] → Edit → Advanced User Details → Marketing User ✓**
+**For production / customer orgs:** create a dedicated API user for the integration and enable Marketing User on that account (**Setup → Users → [user] → Edit → Advanced User Details → Marketing User ✓**). Using a dedicated user isolates the integration's permissions and avoids the connection breaking if a real user's account is deactivated.
+
+**For development / testing:** enable Marketing User on your own Salesforce account before going through the OAuth flow.

--- a/packages/v1-ready/salesforce/README.md
+++ b/packages/v1-ready/salesforce/README.md
@@ -27,10 +27,19 @@ When configuring the Connected App, add both of the following scopes:
 
 In the Connected App's OAuth policies, set **Refresh Token Policy** to **"Refresh token is valid until revoked"**. This prevents the refresh token from expiring on a schedule and breaking the integration unexpectedly.
 
-### Marketing User requirement
+### Integration user
 
-The Salesforce user who authorizes the OAuth connection must be marked as a **Marketing User**. This grants the integration permission to create and manage Campaigns in Salesforce — without it, campaign creation will fail.
+For production and customer orgs, create a **dedicated integration user** in Salesforce rather than authorizing as a real person. This isolates the integration's permissions and prevents the connection from breaking if an employee's account is deactivated.
 
-**For production / customer orgs:** create a dedicated API user for the integration and enable Marketing User on that account (**Setup → Users → [user] → Edit → Advanced User Details → Marketing User ✓**). Using a dedicated user isolates the integration's permissions and avoids the connection breaking if a real user's account is deactivated.
+For development and testing, you can authorize with your own Salesforce account.
 
-**For development / testing:** enable Marketing User on your own Salesforce account before going through the OAuth flow.
+### Conditional permissions
+
+The integration user needs additional permissions depending on which Salesforce objects your integration touches. Grant only what applies:
+
+| Salesforce objects | Required permission |
+| --- | --- |
+| **Campaigns, CampaignMembers** | Enable the **Marketing User** checkbox on the user record (**Setup → Users → [user] → Edit → Advanced User Details → Marketing User ✓**). This is a feature gate separate from object-level CRUD — even a user with full Edit on Campaigns cannot insert a Campaign without it. |
+| **Contacts, Accounts, Leads, Opportunities** | Standard API access is sufficient. No additional flags needed beyond the base integration user profile. |
+
+> **Open question — license compatibility:** The Marketing User flag historically consumes a Marketing User feature license. It is currently unconfirmed whether this flag can be assigned to a Salesforce Integration User license (which is stripped-down and cheaper). If your integration creates Campaigns and you plan to use an Integration license, verify this in a Developer org before advising customers — it may require a full Salesforce seat instead.

--- a/packages/v1-ready/salesforce/README.md
+++ b/packages/v1-ready/salesforce/README.md
@@ -3,7 +3,8 @@
 This is the API Module for salesforce that allows the [Frigg](https://friggframework.org) code to talk to the salesforce
 API.
 
-Read more on the [Frigg documentation site](https://docs.friggframework.org/api-modules/list/salesforce
+Read more on the [Frigg documentation site](https://docs.friggframework.org/api-modules/list/salesforce)
+
 
 ## Salesforce Connected App Setup
 

--- a/packages/v1-ready/salesforce/README.md
+++ b/packages/v1-ready/salesforce/README.md
@@ -4,3 +4,31 @@ This is the API Module for salesforce that allows the [Frigg](https://friggframe
 API.
 
 Read more on the [Frigg documentation site](https://docs.friggframework.org/api-modules/list/salesforce
+
+## Salesforce Connected App Setup
+
+This module requires a Salesforce Connected App to authenticate via OAuth 2.0.
+
+### App type: use "New Connected App" (not "External Client App")
+
+Salesforce offers two app types — the choice matters for cross-org OAuth:
+
+- **New Connected App** (`Setup → Apps → External Client Apps → Settings → New Connected App`) — supports OAuth across **multiple Salesforce orgs**. This is what you need so that users from any org can authorize the integration.
+- **External Client App** (created directly under `Setup → Apps → External Client Apps`) — only works **within the same org** it was created in. Do not use this type for a multi-tenant integration.
+
+### Required OAuth scopes
+
+When configuring the Connected App, add both of the following scopes:
+
+- **Full access (`full`)**
+- **Perform requests at any time (`refresh_token, offline_access`)**
+
+### Refresh token expiry
+
+In the Connected App's OAuth policies, set **Refresh Token Policy** to **"Refresh token is valid until revoked"**. This prevents the refresh token from expiring on a schedule and breaking the integration unexpectedly.
+
+### Marketing User requirement
+
+The Salesforce user who authorizes the OAuth connection must be marked as a **Marketing User**. This grants the integration permission to create and manage Campaigns in Salesforce — without it, campaign creation will fail.
+
+To enable it: **Setup → Users → [user] → Edit → Advanced User Details → Marketing User ✓**


### PR DESCRIPTION
## Summary

- Documents the correct app type to use ("New Connected App" via External Client Apps) and why it supports cross-org OAuth while "External Client App" does not
- Lists required OAuth scopes (`full` and `refresh_token, offline_access`)
- Notes the Refresh Token Policy must be set to "valid until revoked"
- Notes the authorizing user must be marked as Marketing User to allow campaign creation

## Test plan

- [ ] Review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)