### PR TITLE
fix(attio): assert the token is active in testAuthRequest

### DIFF
--- a/packages/v1-ready/attio/definition.js
+++ b/packages/v1-ready/attio/definition.js
@@ -49,7 +49,15 @@ const Definition = {
                 details: {}
             };
         },
-        testAuthRequest: async (api) => api.getUserDetails(),
+        testAuthRequest: async (api) => {
+            const self = await api.getUserDetails();
+
+            if (!self?.active) {
+                throw new Error('Attio token is not active');
+            }
+
+            return self;
+        },
     },
     env: {
         client_id: process.env.ATTIO_CLIENT_ID,

--- a/packages/v1-ready/attio/tests/definition.test.js
+++ b/packages/v1-ready/attio/tests/definition.test.js
@@ -1,0 +1,88 @@
+const { Definition } = require('../definition');
+
+const { requiredAuthMethods } = Definition;
+
+const activeSelf = {
+    active: true,
+    workspace_id: 'e5f0c9a2-1b3d-4a7e-9c8f-0d1e2f3a4b5c',
+    workspace_name: 'Test Workspace',
+    workspace_slug: 'test-workspace',
+};
+
+const revokedSelf = { active: false };
+
+function makeStubApi(userDetails) {
+    return {
+        getUserDetails: async () => userDetails,
+    };
+}
+
+describe('Attio Definition', () => {
+    describe('testAuthRequest()', () => {
+        it('resolves with the self payload for an active token', async () => {
+            const api = makeStubApi(activeSelf);
+
+            await expect(
+                requiredAuthMethods.testAuthRequest(api)
+            ).resolves.toEqual(activeSelf);
+        });
+
+        it('rejects when Attio reports the token as inactive', async () => {
+            const api = makeStubApi(revokedSelf);
+
+            await expect(
+                requiredAuthMethods.testAuthRequest(api)
+            ).rejects.toThrow(/not active/i);
+        });
+
+        it('rejects when the self payload omits the active member', async () => {
+            const api = makeStubApi({ workspace_id: 'no-active-member' });
+
+            await expect(
+                requiredAuthMethods.testAuthRequest(api)
+            ).rejects.toThrow(/not active/i);
+        });
+
+        it('rejects when the self payload is empty', async () => {
+            const api = makeStubApi(undefined);
+
+            await expect(
+                requiredAuthMethods.testAuthRequest(api)
+            ).rejects.toThrow(/not active/i);
+        });
+    });
+
+    describe('getCredentialDetails()', () => {
+        it('returns the workspace identifiers for an active token', async () => {
+            const api = makeStubApi(activeSelf);
+
+            const result = await requiredAuthMethods.getCredentialDetails(
+                api,
+                'user-123'
+            );
+
+            expect(result.identifiers).toEqual({
+                externalId: activeSelf.workspace_id,
+                userId: 'user-123',
+            });
+        });
+
+        it('rejects for a revoked token, which carries no workspace_id', async () => {
+            const api = makeStubApi(revokedSelf);
+
+            await expect(
+                requiredAuthMethods.getCredentialDetails(api, 'user-123')
+            ).rejects.toThrow(/workspace info/i);
+        });
+    });
+
+    describe('getEntityDetails()', () => {
+        it('rejects for a revoked token, which carries no workspace_id', async () => {
+            const api = makeStubApi(revokedSelf);
+
+            await expect(
+                requiredAuthMethods.getEntityDetails(api, null, null, 'user-123')
+            ).rejects.toThrow(/workspace info/i);
+        });
+    });
+});


### PR DESCRIPTION
### Summary

- `testAuthRequest` now asserts `active === true` instead of relying on the response being truthy, so a revoked Attio token is correctly reported as invalid.
- Adds the attio package's first tests (7).

### Why

From [Attio's docs](https://docs.attio.com/rest-api/endpoint-reference/meta/identify), verbatim:

> Unknown, revoked, and deleted tokens are not treated as an error. They return `200` with `{"active": false}` and no other members.

Core's `Module.testAuth()` is a pure truthiness check:

```js
// @friggframework/core — modules/module.js
async testAuth() {
    let validAuth = false;
    try {
        if (await this.testAuthRequest(this.api)) validAuth = true;
    } catch (e) { flushDebugLog(e); }
    return validAuth;
}
```

`testAuthRequest` was `async (api) => api.getUserDetails()` → `GET /v2/self`. A `200 {"active": false}` body is a **truthy object**, so `testAuth()` returned `true` for a revoked token.

Attio access tokens never expire (`exp` is always null) — they are only ever revoked — so `/v2/self` returning `active:false` is precisely the failure mode that matters for this module.

This silently breaks anything built on `testAuth()`. Concretely it blocks credential-recovery / self-heal tooling: such a script re-enables the dead integration, which 401s on its next request and flips straight back to ERROR. Against the production fleet consuming this module that is ~72 integrations flapping, each paying the full retry ladder per webhook delivery.

### Changes

`packages/v1-ready/attio/definition.js`:

```diff
-        testAuthRequest: async (api) => api.getUserDetails(),
+        testAuthRequest: async (api) => {
+            const self = await api.getUserDetails();
+
+            // Attio answers 200 {"active": false} for revoked, deleted and
+            // unknown tokens, and core's testAuth() is a pure truthiness
+            // check, so a truthy body is not proof of a live token.
+            if (!self?.active) {
+                throw new Error('Attio token is not active');
+            }
+
+            return self;
+        },
```

`packages/v1-ready/attio/tests/definition.test.js` (new, 7 tests) covers `testAuthRequest` for active / inactive / missing-`active` / empty payloads, plus `getCredentialDetails` and `getEntityDetails`.

**`getCredentialDetails` and `getEntityDetails` needed no change** — both already throw when `workspace_id` is absent, which is always the case when the token is inactive. That was verified rather than assumed: those tests were green in the red run, and they are included so the guarantee cannot silently regress.

`getUserDetails` has exactly three callers, all in `definition.js`, so nothing else depended on the lenient behaviour.

### Testing

Genuine red → green observed. Before the change the three rejection tests failed with `Received promise resolved instead of rejected / Resolved to value: {"active": false}`. After: 7/7 pass. Also verified end-to-end against core's real `testAuth()` — revoked now yields `false`, live yields `true`.

Note the package had **no tests at all** before this, so there is no prior baseline to compare against.

Unrelated pre-existing issue found while getting the suite to run: `@friggframework/core@2.0.0-next.75` requires `@aws-sdk/client-scheduler` at module load but declares it in neither `dependencies`, `peerDependencies`, nor `optionalDependencies`, so any package's tests fail to load without it (hubspot's committed tests fail identically). Worth a separate core packaging fix.

### Related Issues

Unblocks the credential-recovery admin script in OpenPhone/integrations#80, which must exclude Attio until this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @friggframework/api-module-attio@1.0.1-canary.96.18762aa.0
  npm install @friggframework/api-module-salesforce@1.0.3-canary.96.18762aa.0
  # or 
  yarn add @friggframework/api-module-attio@1.0.1-canary.96.18762aa.0
  yarn add @friggframework/api-module-salesforce@1.0.3-canary.96.18762aa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@friggframework/api-module-attio@1.1.0-next.5`
`@friggframework/api-module-salesforce@2.0.0-next.7`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@friggframework/api-module-attio`
    - fix(attio): assert the token is active in testAuthRequest [#96](https://github.com/friggframework/api-module-library/pull/96) ([@d-klotz](https://github.com/d-klotz))
  - `@friggframework/api-module-salesforce`
    - docs(salesforce): add Connected App setup instructions [#95](https://github.com/friggframework/api-module-library/pull/95) ([@roboli](https://github.com/roboli))
  - `@friggframework/api-module-microsoft-teams`, `@friggframework/api-module-slack`, `@friggframework/api-module-42matters`, `@friggframework/api-module-asana`, `@friggframework/api-module-attio`, `@friggframework/api-module-clio`, `@friggframework/api-module-connectwise`, `@friggframework/api-module-contentful`, `@friggframework/api-module-contentstack`, `@friggframework/api-module-crossbeam`, `@friggframework/api-module-deel`, `@friggframework/api-module-frigg-scale-test`, `@friggframework/api-module-frontify`, `@friggframework/api-module-google-calendar`, `@friggframework/api-module-google-drive`, `@friggframework/api-module-helpscout`, `@friggframework/api-module-hubspot`, `@friggframework/api-module-ironclad`, `@friggframework/api-module-linear`, `@friggframework/api-module-pipedrive`, `@friggframework/api-module-salesforce`, `@friggframework/api-module-stripe`, `@friggframework/api-module-unbabel-projects`, `@friggframework/api-module-unbabel`, `@friggframework/api-module-zoho-crm`, `@friggframework/api-module-zoom`
    - fix(hubspot): align getToken + getEntityDetails with current core contract [#94](https://github.com/friggframework/api-module-library/pull/94) ([@d-klotz](https://github.com/d-klotz))
  
  #### Authors: 2
  
  - Daniel Klotz ([@d-klotz](https://github.com/d-klotz))
  - Roberto Oliveros ([@roboli](https://github.com/roboli))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
